### PR TITLE
miscellaneous improvements from the repair branch

### DIFF
--- a/generator/config/generator/tsl_generator_schema.yaml
+++ b/generator/config/generator/tsl_generator_schema.yaml
@@ -249,6 +249,23 @@ template_parameter: &template_parameter
     name:
       type: "str"
       brief: "Name of template parameter."
+  optional:
+    default_value:
+        type: "str"
+        brief: "A default value."
+        default: ""
+        
+additional_simd_template_parameter: &additional_simd_template_parameter
+  required:
+    name:
+      type: "str"
+      default: ""
+      brief: "Name of template parameter."
+  optional:
+    default_value: 
+      type: "str"
+      default: ""
+      brief: "default value for the template parameter"
 
 primitive:
   required:
@@ -310,9 +327,10 @@ primitive:
       default: { "ctype": "void", "description": "" }
       brief: "The return type of the primitive. (default = void)"
     additional_simd_template_parameter:
-      type: "str"
-      default: ""
-      brief: "Additional template parameter which may be used for conversion operations."
+      type: "dict"
+      entry_type: *additional_simd_template_parameter
+      default: { "name": "", "default_value": "" }
+      brief: "Additional template parameter which may be used for conversion operations."  
     additional_non_specialized_template_parameters:
       type: "list"
       entry_type: *template_parameter

--- a/generator/config/generator/tsl_templates/core/doxygen_function.template
+++ b/generator/config/generator/tsl_templates/core/doxygen_function.template
@@ -1,10 +1,10 @@
-   /*
-    * \brief {{ brief_description }}
-    * \details {{ detailed_description }}
-    {% for param in parameters %}
-    * \param {{ param['name'] }} {{ param['description'] }}
-    {% endfor %}
-    {% if returns['ctype'] != 'void' %}
-    * \return {{ returns['description'] }}
-    {% endif %}
-    */
+/*
+ * \brief {{ brief_description }}
+ * \details {{ detailed_description }}
+ {% for param in parameters %}
+ * \param {{ param['name'] }} {{ param['description'] }}
+ {% endfor %}
+ {% if returns['ctype'] != 'void' %}
+ * \return {{ returns['description'] }}
+ {% endif %}
+ */

--- a/generator/config/generator/tsl_templates/core/header_file.template
+++ b/generator/config/generator/tsl_templates/core/header_file.template
@@ -2,10 +2,8 @@
 
 {% include 'core/doxygen_file.template' %}
 
-
 #ifndef {{ tsl_include_guard }}
 #define {{ tsl_include_guard }}
-
 {% if preliminary_defines is defined %}
 {% for preliminary_define in preliminary_defines %}
 {{preliminary_define}}
@@ -16,6 +14,7 @@
 #include {{ include }}
 {% endfor %}
 #include <tuple>
+
 {% if codes %}
 namespace {{ tsl_namespace }} {
 {% if nested_namespaces is defined %}
@@ -23,12 +22,12 @@ namespace {{ tsl_namespace }} {
 namespace {{ nested_namespace }} {
 {% endfor %}
 {% endif %}
-
+{%- filter indent(width=4) +%}
 {%    for code in codes %}
 {{ code }}
 
 {%    endfor %}
-
+{% endfilter %}
 {% if nested_namespaces %}
 {% for nested_namespace in nested_namespaces %}
 } // end of namespace {{ nested_namespace }}

--- a/generator/config/generator/tsl_templates/core/header_file.template
+++ b/generator/config/generator/tsl_templates/core/header_file.template
@@ -23,9 +23,12 @@ namespace {{ tsl_namespace }} {
 namespace {{ nested_namespace }} {
 {% endfor %}
 {% endif %}
+
 {%    for code in codes %}
-   {{ code }}
+{{ code }}
+
 {%    endfor %}
+
 {% if nested_namespaces %}
 {% for nested_namespace in nested_namespaces %}
 } // end of namespace {{ nested_namespace }}

--- a/generator/config/generator/tsl_templates/core/primitive_declaration.template
+++ b/generator/config/generator/tsl_templates/core/primitive_declaration.template
@@ -5,11 +5,12 @@
    full_qualified_parameters_str='',
    parameters_str='',
    additional_template_type_name='',
+   additional_template_params_with_defaults='',
    additional_template_name=''
    ) %}
 {% for param in parameters %}
    {% if not loop.last %}
-      {% set comma = ',' %}
+      {% set comma = ', ' %}
    {% else %}
       {% set comma = '' %}
    {% endif %}
@@ -25,9 +26,9 @@
         {% set dv = '' %}
       {% endif %}
       {% if 'declaration_attributes' in param and param['declaration_attributes'] != ""%}
-          {% set decl_attribs = ' ' ~ param['declaration_attributes'] ~ ' ' %}
+          {% set decl_attribs = param['declaration_attributes'] ~ ' ' %}
       {% else %}
-          {% set decl_attribs = ' ' %}
+          {% set decl_attribs = '' %}
       {% endif %}
       {% if 'attributes' in param and param['attributes'] != "" %}
 	     {% set attribs = ' ' ~ param['attributes'] ~ ' ' %}
@@ -41,18 +42,29 @@
 {% if ns.contains_parameter_pack %}
 {% set ns.parameter_pack_typenames_str = ', ' ~ ns.parameter_pack_typenames_str %}
 {% endif %}
-{% if additional_simd_template_parameter != "" %}
-{% set ns.additional_template_type_name = 'typename ' ~ additional_simd_template_parameter ~ ', ' %}
-{% set ns.additional_template_name = additional_simd_template_parameter ~ ', '%}
+{% if additional_simd_template_parameter["name"] != "" %}
+{% set ns.additional_template_type_name = 'typename ' ~ additional_simd_template_parameter["name"] ~ ', ' %}
+{% set ns.additional_template_params_with_defaults = 'typename ' ~ additional_simd_template_parameter["name"] %}
+{% if additional_simd_template_parameter["default_value"] != "" %}
+{% set ns.additional_template_params_with_defaults = ns.additional_template_params_with_defaults ~ " = " ~ additional_simd_template_parameter["default_value"] ~ ", "%}
+{% else %}
+{% set ns.additional_template_params_with_defaults = ns.additional_template_params_with_defaults ~ ", "%}
+{% endif %}
+{% set ns.additional_template_name =  additional_simd_template_parameter["name"] ~ ', '%}
 {% endif %}
 {% if additional_non_specialized_template_parameters|length > 0 %}
-{% set rtp_ns = namespace(types='', params='') %}
+{% set rtp_ns = namespace(types='', params='', params_with_defaults='') %}
 {% for parameter_dict in additional_non_specialized_template_parameters %}
 {% set loop_comma = '' if loop.first else ', ' %}
-{% set rtp_ns.types = rtp_ns.types ~ loop_comma ~ parameter_dict["ctype"] ~ ' ' ~ parameter_dict["name"] %}
 {% set rtp_ns.params = rtp_ns.params ~ loop_comma ~ parameter_dict["name"] %}
+{% set rtp_ns.types = rtp_ns.types ~ loop_comma ~ parameter_dict["ctype"] ~ ' ' ~ parameter_dict["name"] %}
+{% set rtp_ns.params_with_defaults = rtp_ns.params_with_defaults ~ loop_comma ~ parameter_dict["ctype"] ~ ' ' ~ parameter_dict["name"] %}
+{% if parameter_dict["default_value"] != "" %}
+{% set rtp_ns.params_with_defaults = rtp_ns.params_with_defaults ~ ' = ' ~ parameter_dict["default_value"] %}
+{% endif %}
 {% endfor %}
 {% set ns.additional_template_type_name = ns.additional_template_type_name ~ rtp_ns.types ~ ", "%}
+{% set ns.additional_template_params_with_defaults = ns.additional_template_params_with_defaults ~ rtp_ns.params_with_defaults ~ ", "%}
 {% set ns.additional_template_name = ns.additional_template_name ~ rtp_ns.params ~ ", "%}
 {% endif %}
 
@@ -60,34 +72,35 @@
 namespace {{ tsl_implementation_namespace }} {
 {# This is the forward declaration of the actual primitive implementation struct #}
       // Definition of a preprocessor variable to detect overload ambiguity.
-      #define {{ tsl_namespace|upper ~ '_' ~ tsl_implementation_namespace|upper ~ '_' ~ functor_name|upper ~ '_STRUCT_DEFINED'}}
+    #define {{ tsl_namespace|upper ~ '_' ~ tsl_implementation_namespace|upper ~ '_' ~ functor_name|upper ~ '_STRUCT_DEFINED'}}
       // Forward declaration of implementation struct for TSL-primitive "{{ functor_name }}".
-      template<VectorProcessingStyle {{ vector_name }}, {{ ns.additional_template_type_name}}ImplementationDegreeOfFreedom {{ idof_name }}>
-         struct {{ functor_name }}{};
-   }
+    template<VectorProcessingStyle {{ vector_name }}, {{ ns.additional_template_type_name}}ImplementationDegreeOfFreedom {{ idof_name }}>
+        struct {{ functor_name }}{};
+    }
 {{ tsl_function_doxygen }}
    {# This is the templated free function for the primitive which is called by the user of TSL. #}
-   template<
-      VectorProcessingStyle {{ vector_name }}
-      , {{ ns.additional_template_type_name}}ImplementationDegreeOfFreedom {{ idof_name }} = workaround{{ ns.parameter_pack_typenames_str }}
-      {% if functor_name != primitive_name %}
-      #ifdef {{ tsl_namespace|upper ~ '_' ~ tsl_implementation_namespace|upper ~ '_' ~ primitive_name|upper ~ '_STRUCT_DEFINED'}}
-      , typename std::enable_if_t<
-         !std::is_same_v<
-            typename {{ tsl_implementation_namespace }}::{{ primitive_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::param_tuple_t,
-            typename {{ tsl_implementation_namespace }}::{{ functor_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::param_tuple_t>,
-         std::nullptr_t
-    > = nullptr
-      #endif
-      {% endif %}
-   >
-   {# If the primitive returns something, the caller has to capture the result. #}
-      {{ '[[nodiscard]] ' if returns['ctype'] != 'void' else '' }}{# If force_inline is set to True, we use TSL_FORCE_INLINE. #}{{ 'TSL_FORCE_INLINE ' if force_inline else '' }}{{ returns['ctype'] }} {{ primitive_name }}(
-         {{ ns.full_qualified_parameters_str }}
-      ) {
-      {# If the function primitive implementation returns something we have to return it, otherwise we just call it. #}
-      {# Call the actual implementation with all parameters. #}
-         {{ 'return ' if returns['ctype'] != 'void' else '' }}{{ tsl_implementation_namespace }}::{{ functor_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::apply(
+    template<
+        VectorProcessingStyle {{ vector_name }},
+        {{ ns.additional_template_params_with_defaults}}ImplementationDegreeOfFreedom {{ idof_name }} = workaround{{ ns.parameter_pack_typenames_str }}
+        {% if functor_name != primitive_name %}
+        #ifdef {{ tsl_namespace|upper ~ '_' ~ tsl_implementation_namespace|upper ~ '_' ~ primitive_name|upper ~ '_STRUCT_DEFINED'}}
+        , typename std::enable_if_t<
+            !std::is_same_v<
+                typename {{ tsl_implementation_namespace }}::{{ primitive_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::param_tuple_t,
+                typename {{ tsl_implementation_namespace }}::{{ functor_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::param_tuple_t
+            >,
+            std::nullptr_t
+        > = nullptr
+        #endif
+        {% endif %}
+    >
+    {# If the primitive returns something, the caller has to capture the result. #}
+    {{ '[[nodiscard]] ' if returns['ctype'] != 'void' else '' }}{# If force_inline is set to True, we use TSL_FORCE_INLINE. #}{{ 'TSL_FORCE_INLINE ' if force_inline else '' }}{{ returns['ctype'] }} {{ primitive_name }}(
+        {{ ns.full_qualified_parameters_str }}
+    ) {
+        {# If the function primitive implementation returns something we have to return it, otherwise we just call it. #}
+        {# Call the actual implementation with all parameters. #}
+        {{ 'return ' if returns['ctype'] != 'void' else '' }}{{ tsl_implementation_namespace }}::{{ functor_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::apply(
             {{ ns.parameters_str }}
-         );
-      }
+        );
+    }

--- a/generator/config/generator/tsl_templates/core/primitive_declaration.template
+++ b/generator/config/generator/tsl_templates/core/primitive_declaration.template
@@ -67,40 +67,40 @@
 {% set ns.additional_template_params_with_defaults = ns.additional_template_params_with_defaults ~ rtp_ns.params_with_defaults ~ ", "%}
 {% set ns.additional_template_name = ns.additional_template_name ~ rtp_ns.params ~ ", "%}
 {% endif %}
-
 {# Every implementation is in the (nested) namespace "functors" #}
 namespace {{ tsl_implementation_namespace }} {
 {# This is the forward declaration of the actual primitive implementation struct #}
-      // Definition of a preprocessor variable to detect overload ambiguity.
+    // Definition of a preprocessor variable to detect overload ambiguity.
     #define {{ tsl_namespace|upper ~ '_' ~ tsl_implementation_namespace|upper ~ '_' ~ functor_name|upper ~ '_STRUCT_DEFINED'}}
-      // Forward declaration of implementation struct for TSL-primitive "{{ functor_name }}".
+    // Forward declaration of implementation struct for TSL-primitive "{{ functor_name }}".
     template<VectorProcessingStyle {{ vector_name }}, {{ ns.additional_template_type_name}}ImplementationDegreeOfFreedom {{ idof_name }}>
-        struct {{ functor_name }}{};
-    }
+    struct {{ functor_name }}{};
+}
+
 {{ tsl_function_doxygen }}
-   {# This is the templated free function for the primitive which is called by the user of TSL. #}
-    template<
-        VectorProcessingStyle {{ vector_name }},
-        {{ ns.additional_template_params_with_defaults}}ImplementationDegreeOfFreedom {{ idof_name }} = workaround{{ ns.parameter_pack_typenames_str }}
-        {% if functor_name != primitive_name %}
-        #ifdef {{ tsl_namespace|upper ~ '_' ~ tsl_implementation_namespace|upper ~ '_' ~ primitive_name|upper ~ '_STRUCT_DEFINED'}}
-        , typename std::enable_if_t<
-            !std::is_same_v<
-                typename {{ tsl_implementation_namespace }}::{{ primitive_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::param_tuple_t,
-                typename {{ tsl_implementation_namespace }}::{{ functor_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::param_tuple_t
-            >,
-            std::nullptr_t
-        > = nullptr
-        #endif
-        {% endif %}
-    >
-    {# If the primitive returns something, the caller has to capture the result. #}
-    {{ '[[nodiscard]] ' if returns['ctype'] != 'void' else '' }}{# If force_inline is set to True, we use TSL_FORCE_INLINE. #}{{ 'TSL_FORCE_INLINE ' if force_inline else '' }}{{ returns['ctype'] }} {{ primitive_name }}(
-        {{ ns.full_qualified_parameters_str }}
-    ) {
-        {# If the function primitive implementation returns something we have to return it, otherwise we just call it. #}
-        {# Call the actual implementation with all parameters. #}
-        {{ 'return ' if returns['ctype'] != 'void' else '' }}{{ tsl_implementation_namespace }}::{{ functor_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::apply(
-            {{ ns.parameters_str }}
-        );
-    }
+{# This is the templated free function for the primitive which is called by the user of TSL. #}
+template<
+    VectorProcessingStyle {{ vector_name }},
+    {{ ns.additional_template_params_with_defaults}}ImplementationDegreeOfFreedom {{ idof_name }} = workaround{{ ns.parameter_pack_typenames_str }}
+    {% if functor_name != primitive_name %}
+    #ifdef {{ tsl_namespace|upper ~ '_' ~ tsl_implementation_namespace|upper ~ '_' ~ primitive_name|upper ~ '_STRUCT_DEFINED'}}
+    , typename std::enable_if_t<
+        !std::is_same_v<
+            typename {{ tsl_implementation_namespace }}::{{ primitive_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::param_tuple_t,
+            typename {{ tsl_implementation_namespace }}::{{ functor_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::param_tuple_t
+        >,
+        std::nullptr_t
+    > = nullptr
+    #endif
+    {% endif %}
+>
+{# If the primitive returns something, the caller has to capture the result. #}
+{{ '[[nodiscard]] ' if returns['ctype'] != 'void' else '' }}{# If force_inline is set to True, we use TSL_FORCE_INLINE. #}{{ 'TSL_FORCE_INLINE ' if force_inline else '' }}{{ returns['ctype'] }} {{ primitive_name }}(
+    {{ ns.full_qualified_parameters_str }}
+) {
+    {# If the function primitive implementation returns something we have to return it, otherwise we just call it. #}
+    {# Call the actual implementation with all parameters. #}
+    {{ 'return ' if returns['ctype'] != 'void' else '' }}{{ tsl_implementation_namespace }}::{{ functor_name }}<{{ vector_name }}, {{ ns.additional_template_name }}{{ idof_name }}>::apply(
+        {{ ns.parameters_str }}
+    );
+}

--- a/generator/config/generator/tsl_templates/core/primitive_definition.template
+++ b/generator/config/generator/tsl_templates/core/primitive_definition.template
@@ -35,7 +35,7 @@
 {% endif %}
 {% for param in parameters %}
    {% if not loop.last %}
-      {% set comma = ',' %}
+      {% set comma = ', ' %}
    {% else %}
       {% set comma = '' %}
    {% endif %}
@@ -48,9 +48,9 @@
       {% set ns.has_parameters_tuple = False %}
    {% else %}
       {% if 'declaration_attributes' not in param or param['declaration_attributes'] == "" %}
-      {% set decl_attribs = ' ' %}
+      {% set decl_attribs = '' %}
       {% else %}
-      {% set decl_attribs = ' ' ~ param['declaration_attributes'] ~ ' ' %}
+      {% set decl_attribs = param['declaration_attributes'] ~ ' ' %}
       {% endif %}
       {% if 'attributes' not in param or param['attributes'] == "" %}
       {% set attribs = ' ' %}
@@ -82,55 +82,55 @@
 {% endif %}
 {# Every implementation is in the (nested) namespace "details" #}
 namespace {{ tsl_implementation_namespace }} {
-      /**
-       * @brief: Template specialization of implementation for "{{ functor_name }}" (primitive {{ primitive_name }}).
-       * @details:
-       * Target Extension: {{ target_extension }}.
-       *        Data Type: {{ ctype }}
-       *  Extension Flags: {{ lscpu_flags }}
-       {% if yaml_origin_line and yaml_origin_file %}
-       *      Yaml Source: {{ yaml_origin_file }}::{{ yaml_origin_line }}
-       {% endif %}
-       {% if specialization_comment != "" %}
-       * @note: {{ specialization_comment }}
-       {% endif %}
-       */
-      template<{{ 'typename T, ' if ns.partial_specialized else '' }}{{ 'std::size_t VectorSize, ' if vector_length_agnostic else '' }}{{ ns.additional_templates }}ImplementationDegreeOfFreedom {{ idof_name }}>
+    /**
+     * @brief: Template specialization of implementation for "{{ functor_name }}" (primitive {{ primitive_name }}).
+     * @details:
+     * Target Extension: {{ target_extension }}.
+     *        Data Type: {{ ctype }}
+     *  Extension Flags: {{ lscpu_flags }}
+     {% if yaml_origin_line and yaml_origin_file %}
+     *      Yaml Source: {{ yaml_origin_file }}::{{ yaml_origin_line }}
+     {% endif %}
+     {% if specialization_comment != "" %}
+     * @note: {{ specialization_comment }}
+     {% endif %}
+     */
+    template<{{ 'typename T, ' if ns.partial_specialized else '' }}{{ 'std::size_t VectorSize, ' if vector_length_agnostic else '' }}{{ ns.additional_templates }}ImplementationDegreeOfFreedom {{ idof_name }}>
 {# If the vector_length_bits is specified in the yaml file, a specialization is generated. #}
-         struct {{ functor_name }}<{{ ns.full_extension_name }}, {{ ns.return_template_type }}{{ ns.additional_template_params }}{{ idof_name }}> {
-            using {{ vector_name }} = {{ ns.full_extension_name }};
-            {{ ns.using_return_type }}
-            using return_type = {{ returns['ctype'] }};
-            {% if ns.has_parameters_tuple %}
-            using param_tuple_t = std::tuple<{{ ns.parameters_types }}>;
+    struct {{ functor_name }}<{{ ns.full_extension_name }}, {{ ns.return_template_type }}{{ ns.additional_template_params }}{{ idof_name }}> {
+        using {{ vector_name }} = {{ ns.full_extension_name }};
+        {{ ns.using_return_type }}
+        using return_type = {{ returns['ctype'] }};
+        {% if ns.has_parameters_tuple %}
+        using param_tuple_t = std::tuple<{{ ns.parameters_types }}>;
+        {% endif %}
+        static constexpr bool parameters_queryable() {
+            return {{ 'true' if ns.has_parameters_tuple else 'false' }};
+        }
+        static constexpr bool has_return_value() {
+            return {{ 'true' if returns['ctype'] != 'void' else 'false' }};
+        }
+        static constexpr bool native_supported() {
+{# If there is hardware support this function returns true, false otherwise. #}
+            return {{ 'true;' if is_native else 'false;' }}
+        }
+{% if ns.contains_parameter_pack %}
+        template< {{ ns.parameter_pack_typenames_str }} >
+{% endif %}
+{# If the primitive returns something, the caller has to capture the result. #}
+        {{ '[[nodiscard]] ' if returns['ctype'] != 'void' else ''}}{{ '' if is_native else "TSL_NO_NATIVE_SUPPORT_WARNING" }}
+{# If force_inline is set to True, we use TSL_FORCE_INLINE. #}
+        {{ 'TSL_FORCE_INLINE ' if force_inline else '' }}
+        static {{ returns['ctype'] }} apply(
+{# Iterate over all parameters and write them out. #}
+            {{ ns.full_qualified_parameters_str }}
+        ) {
+            {%- if not is_native +%}
+            static_assert( !std::is_same_v< {{ idof_name }}, native >, "The primitive {{ functor_name }} is not supported by your hardware natively while it is forced by using native" );
             {% endif %}
-            static constexpr bool parameters_queryable() {
-               return {{ 'true' if ns.has_parameters_tuple else 'false' }};
-            }
-            static constexpr bool has_return_value() {
-                return {{ 'true' if returns['ctype'] != 'void' else 'false' }};
-            }
-            static constexpr bool native_supported() {
-   {# If there is hardware support this function returns true, false otherwise. #}
-               return {{ 'true;' if is_native else 'false;' }}
-            }
-   {% if ns.contains_parameter_pack %}
-            template< {{ ns.parameter_pack_typenames_str }} >
-   {% endif %}
-   {# If the primitive returns something, the caller has to capture the result. #}
-            {{ '[[nodiscard]] ' if returns['ctype'] != 'void' else ''}}{{ '' if is_native else "TSL_NO_NATIVE_SUPPORT_WARNING" }}
-   {# If force_inline is set to True, we use TSL_FORCE_INLINE. #}
-            {{ 'TSL_FORCE_INLINE ' if force_inline else '' }}
-            static {{ returns['ctype'] }} apply(
-   {# Iterate over all parameters and write them out. #}
-               {{ ns.full_qualified_parameters_str }}
-            ) {
-               {% if not is_native %}
-               static_assert( !std::is_same_v< {{ idof_name }}, native >, "The primitive {{ functor_name }} is not supported by your hardware natively while it is forced by using native" );
-               {% endif %}
-               {% filter indent(width=15) %}
+            {%- filter indent(width=12) +%}
 {{ implementation }}
-               {% endfilter %}
-            }
-         };
-   } // end of namespace {{ tsl_implementation_namespace }} for template specialization of {{ functor_name }} for {{ target_extension }} using {{ ctype }}.
+            {% endfilter %}
+        }
+    };
+} // end of namespace {{ tsl_implementation_namespace }} for template specialization of {{ functor_name }} for {{ target_extension }} using {{ ctype }}.

--- a/generator/config/generator/tsl_templates/core/primitive_definition.template
+++ b/generator/config/generator/tsl_templates/core/primitive_definition.template
@@ -62,13 +62,13 @@
       {% set ns.parameters_types = ns.parameters_types ~ param['ctype'] ~ comma %}
    {% endif %}
 {% endfor %}
-{% if additional_simd_template_parameter != "" %}
+{% if additional_simd_template_parameter["name"] != "" %}
     {% if additional_simd_template_extension != "" %}
         {% set ns.additional_target_extension = additional_simd_template_extension %}
     {% else %}
         {% set ns.additional_target_extension = target_extension %}
     {% endif %}
-    {% set ns.using_return_type = 'using ' ~ additional_simd_template_parameter ~ ' = simd<' ~ additional_simd_template_base_type ~ ', ' ~ ns.additional_target_extension ~ ns.simd_register_length ~ '>;' %}
+    {% set ns.using_return_type = 'using ' ~ additional_simd_template_parameter["name"] ~ ' = simd<' ~ additional_simd_template_base_type ~ ', ' ~ ns.additional_target_extension ~ ns.simd_register_length ~ '>;' %}
     {% set ns.return_template_type = 'simd<' ~ additional_simd_template_base_type ~ ', ' ~ ns.additional_target_extension ~ ns.simd_register_length ~ '>, ' %}
 {% endif %}
 {% if additional_non_specialized_template_parameters|length > 0 %}

--- a/generator/config/generator/tsl_templates/core/source_file.template
+++ b/generator/config/generator/tsl_templates/core/source_file.template
@@ -1,15 +1,17 @@
 {{ tsl_license }}
+
 {{ tsl_file_doxygen }}
 
 {% if preliminary_defines is defined %}
 {% for preliminary_define in preliminary_defines %}
 {{preliminary_define}}
+
 {% endfor %}
 {% endif %}
-
 {% for include in includes %}
 #include {{ include }}
 {% endfor %}
+
 {% for code in codes %}
-   {{ code }}
+{{ code }}
 {% endfor %}

--- a/generator/config/generator/tsl_templates/expansions/unit_test.template
+++ b/generator/config/generator/tsl_templates/expansions/unit_test.template
@@ -1,10 +1,12 @@
 {% macro create_test_call(case, extension, ctype) -%}
 {% if case['conversion_types'] %}
-{%    for conversion_type in case['conversion_types'][extension][ctype] %}
-      CHECK(test_{{ case['primitive_name'] }}_{{ case['test_name'] }}<simd<{{ ctype }}, {{ extension }}>, simd<{{ conversion_type }}, {{ extension }}>>());
+{%    for (additional_extension, conversion_types) in case['conversion_types'][extension].items() %}
+{%      for conversion_type in conversion_types[ctype] %}
+        CHECK(test_{{ case['primitive_name'] }}_{{ case['test_name'] }}<simd<{{ ctype }}, {{ extension }}>, simd<{{ conversion_type }}, {{ additional_extension }}>>());
+{%      endfor %}
 {%    endfor %}
 {% else %}
-      CHECK(test_{{ case['primitive_name'] }}_{{ case['test_name'] }}<simd<{{ ctype }}, {{ extension }}>>());
+        CHECK(test_{{ case['primitive_name'] }}_{{ case['test_name'] }}<simd<{{ ctype }}, {{ extension }}>>());
 {% endif %}
 {%- endmacro -%}
 
@@ -13,16 +15,16 @@ namespace {{ tsl_namespace }} {
   {%    for primitive_test in primitive_class_test['primitive_tests'] %}
   {%       for case in primitive_test['cases'] %}
   {%        if case['conversion_types'] %}
-  template<VectorProcessingStyle {{ primitive_test['vector_name'] }}, VectorProcessingStyle {{ primitive_test['additional_simd_template_parameter'] }}>
+    template<VectorProcessingStyle {{ primitive_test['vector_name'] }}, VectorProcessingStyle {{ primitive_test['additional_simd_template_parameter'] }}>
   {%        else %}
-  template<VectorProcessingStyle {{ primitive_test['vector_name'] }}>
+    template<VectorProcessingStyle {{ primitive_test['vector_name'] }}>
   {%        endif %}
-     bool test_{{ case['primitive_name'] }}_{{ case['test_name'] }}() {
+    bool test_{{ case['primitive_name'] }}_{{ case['test_name'] }}() {
         using namespace {{ tsl_namespace }};
         {%- filter indent(width=8) +%}
 {{ case['implementation'] }}
         {% endfilter %}
-     }
+    }
   {%       endfor %}
   {%    endfor %}
   {% endfor %}
@@ -32,28 +34,28 @@ namespace {{ tsl_namespace }} {
 {%    for primitive_test in primitive_class_test['primitive_tests'] %}
 {%       for extension in known_extensions %}
 TEST_CASE("Testing primitive '{{ primitive_test['functor_name'] }}' for {{ extension }}", "[{{ primitive_test['functor_name'] }}],[{{ extension }}]") {
-   using namespace {{ tsl_namespace }};
+    using namespace {{ tsl_namespace }};
 {%             for case in primitive_test['cases'] %}
-   SECTION("{{ case['test_name'] }}") {
+    SECTION("{{ case['test_name'] }}") {
 {%                   if extension not in case['complete_tests_lib_definitions'] %}
 {%                      set resolved = False %}
 {%                      if case['missing_required_primitive_definitions'] is not none %}
 {%                         if extension in case['missing_required_primitive_definitions'] %}
 {%                            set resolved = True %}
 {%                            for ctype in case['missing_required_primitive_definitions'][extension] %}
-      WARN("Can't run. Required primitive(s) {{ case['missing_required_primitive_definitions'][extension][ctype] }} not provided.");
+        WARN("Can't run. Required primitive(s) {{ case['missing_required_primitive_definitions'][extension][ctype] }} not provided.");
 {%                            endfor %}
 {%                         endif %}
 {%                      endif %}
 {%                      if extension in case['missing_previous_tests'] and not resolved %}
 {%                         set resolved = True %}
 {%                         for ctype in case['missing_required_primitive_definitions'][extension] %}
-      WARN("Unreliable test. Required tests for primitive(s) {{ case['missing_previous_tests'][extension][ctype] }} not provided.");
+        WARN("Unreliable test. Required tests for primitive(s) {{ case['missing_previous_tests'][extension][ctype] }} not provided.");
 {{ create_test_call(case, extension, ctype) }}
 {%                         endfor %}
 {%                      endif %}
 {%                      if not resolved %}
-      WARN("Primitive {{ case['primitive_name'] }} not implemented for {{ extension }}");
+        WARN("Primitive {{ case['primitive_name'] }} not implemented for {{ extension }}");
 {%                      endif %}
 {%                   else %}
 {%                      for ctype in known_ctypes %}
@@ -65,24 +67,24 @@ TEST_CASE("Testing primitive '{{ primitive_test['functor_name'] }}' for {{ exten
 {%                               if extension in case['missing_required_primitive_definitions'] %}
 {%                                  if ctype in case['missing_required_primitive_definitions'][extension] %}
 {%                                     set resolved = True %}
-      WARN("Can't run. Required primitive(s) {{ case['missing_required_primitive_definitions'][extension][ctype] }} not provided.");
+        WARN("Can't run. Required primitive(s) {{ case['missing_required_primitive_definitions'][extension][ctype] }} not provided.");
 {%                                  endif %}
 {%                               endif %}
 {%                            endif %}
 {%                            if extension in case['missing_previous_tests'] and not resolved %}
 {%                               if ctype in case['missing_required_primitive_definitions'][extension] %}
 {%                                  set resolved = True %}
-      WARN("Unreliable test. Required tests for primitive(s) {{ case['missing_previous_tests'][extension][ctype] }} not provided.");
+        WARN("Unreliable test. Required tests for primitive(s) {{ case['missing_previous_tests'][extension][ctype] }} not provided.");
 {{ create_test_call(case, extension, ctype) }}
 {%                               endif %}
 {%                            endif %}
 {%                            if not resolved %}
-      WARN("Primitive {{ case['primitive_name'] }}<simd<{{ ctype }}, {{ extension }}>> not implemented.");
+        WARN("Primitive {{ case['primitive_name'] }}<simd<{{ ctype }}, {{ extension }}>> not implemented.");
 {%                            endif %}
 {%                         endif %}
 {%                      endfor %}
 {%                   endif %}
-   }
+    }
 {%             endfor %}
 }
 {%       endfor %}

--- a/generator/config/generator/tsl_templates/expansions/unit_test.template
+++ b/generator/config/generator/tsl_templates/expansions/unit_test.template
@@ -15,7 +15,7 @@ namespace {{ tsl_namespace }} {
   {%    for primitive_test in primitive_class_test['primitive_tests'] %}
   {%       for case in primitive_test['cases'] %}
   {%        if case['conversion_types'] %}
-    template<VectorProcessingStyle {{ primitive_test['vector_name'] }}, VectorProcessingStyle {{ primitive_test['additional_simd_template_parameter'] }}>
+    template<VectorProcessingStyle {{ primitive_test['vector_name'] }}, VectorProcessingStyle {{ primitive_test['additional_simd_template_parameter']['name'] }}>
   {%        else %}
     template<VectorProcessingStyle {{ primitive_test['vector_name'] }}>
   {%        endif %}

--- a/generator/config/generator/tsl_templates/expansions/unit_test.template
+++ b/generator/config/generator/tsl_templates/expansions/unit_test.template
@@ -11,23 +11,23 @@
 {%- endmacro -%}
 
 namespace {{ tsl_namespace }} {
-  {% for primitive_class_test in tests %}
-  {%    for primitive_test in primitive_class_test['primitive_tests'] %}
-  {%       for case in primitive_test['cases'] %}
-  {%        if case['conversion_types'] %}
+    {% for primitive_class_test in tests %}
+    {%    for primitive_test in primitive_class_test['primitive_tests'] %}
+    {%       for case in primitive_test['cases'] %}
+    {%        if case['conversion_types'] %}
     template<VectorProcessingStyle {{ primitive_test['vector_name'] }}, VectorProcessingStyle {{ primitive_test['additional_simd_template_parameter']['name'] }}>
-  {%        else %}
+    {%        else %}
     template<VectorProcessingStyle {{ primitive_test['vector_name'] }}>
-  {%        endif %}
+    {%        endif %}
     bool test_{{ case['primitive_name'] }}_{{ case['test_name'] }}() {
         using namespace {{ tsl_namespace }};
         {%- filter indent(width=8) +%}
 {{ case['implementation'] }}
         {% endfilter %}
     }
-  {%       endfor %}
-  {%    endfor %}
-  {% endfor %}
+    {%       endfor %}
+    {%    endfor %}
+    {% endfor %}
 }
 
 {% for primitive_class_test in tests %}

--- a/generator/core/model/tsl_primitive.py
+++ b/generator/core/model/tsl_primitive.py
@@ -43,7 +43,7 @@ class TSLPrimitive:
                 setattr(result, k, deepcopy(v, memodict))
             return result
         def has_additional_simd_template_parameters(self) -> bool:
-           return len(self.__data_dict["additional_simd_template_parameter"]) > 0
+           return self.__data_dict["additional_simd_template_parameter"]["name"] != ""
 
     class Definition:
         @classmethod

--- a/generator/core/model/tsl_primitive.py
+++ b/generator/core/model/tsl_primitive.py
@@ -158,6 +158,11 @@ class TSLPrimitive:
         @property
         def additional_simd_template_base_type_mapping_dict(self) -> Dict[str, List[str]]:
             return self.__data_dict["additional_simd_template_base_type_mapping_dict"]
+        
+        @property 
+        def additional_simd_template_extension(self) -> str:
+            aste = self.__data_dict['additional_simd_template_extension']
+            return aste if aste else self.target_extension
 
         def update_types(self, ct: List[str]):
             ctypes = copy.deepcopy(self.ctypes)
@@ -328,15 +333,20 @@ class TSLPrimitive:
                     result[definition.target_extension].append(ctype)
         return result
 
-    def conversion_types(self, specializations: Dict[str, List[str]]) -> Dict[str, Dict[str, List[str]]]:
+    # resulting dict: (extension, additional_simd_template_extension, ctype) -> list of additional_simd_template_base_type
+    def conversion_types(self, specializations: Dict[str, List[str]]) -> Dict[str, Dict[str, Dict[str, List[str]]]]:
         if not self.declaration.has_additional_simd_template_parameters():
             return None
-        result: Dict[str, Dict[str, List[str]]] = {}
+        result: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
         for definition in self.definitions:
             te = definition.target_extension
             if te not in result:
                 result[te] = {}
-            known_conversions = result[te]
+            result_te = result[te]
+            aste = definition.additional_simd_template_extension
+            if aste not in result_te:
+                result_te[aste] = {}
+            known_conversions = result_te[aste]
             tsdict: Dict[str, List[str]] = definition.types_dict
             for tstype in tsdict:
                 if tstype in specializations[te]:

--- a/generator/expansions/tsl_unit_test.py
+++ b/generator/expansions/tsl_unit_test.py
@@ -23,13 +23,13 @@ from generator.utils.yaml_utils import YamlDataType, yaml_load
 import os
 
 class TSLPrimitiveTestCaseData:
-    def __init__(self, class_name: str, primitive_name: str, data_dict: YamlDataType, lib_definitions: Dict[str, List[str]], conversion_types: Dict[str, Dict[str, List[str]]], missing_primitive_definitions: Dict[str, Dict[str, List[str]]]):
+    def __init__(self, class_name: str, primitive_name: str, data_dict: YamlDataType, lib_definitions: Dict[str, List[str]], conversion_types: Dict[str, Dict[str, Dict[str, List[str]]]], missing_primitive_definitions: Dict[str, Dict[str, List[str]]]):
         self.__class_name: str = class_name
         self.__primitive_name: str = primitive_name
         self.__test_name: str = data_dict["test_name"]
         self.__data_dict: YamlDataType = data_dict
         self.__lib_definitions: Dict[str, List[str]] = lib_definitions
-        self.__conversion_types: Dict[str, Dict[str, List[str]]] = conversion_types
+        self.__conversion_types: Dict[str, Dict[str, Dict[str, List[str]]]] = conversion_types
         self.__complete_tests_lib_definitions: Dict[str, List[str]] = lib_definitions
         self.__missing_previous_tests: Dict[str, Dict[str, List[str]]] = dict()
         self.__missing_required_primitive_definitions: Dict[str, Dict[str, List[str]]] = missing_primitive_definitions
@@ -79,7 +79,7 @@ class TSLPrimitiveTestCaseData:
         return copy.deepcopy(self.__lib_definitions)
 
     @property
-    def conversion_types(self) -> Dict[str, Dict[str, List[str]]]:
+    def conversion_types(self) -> Dict[str, Dict[str, Dict[str, List[str]]]]:
         return copy.deepcopy(self.__conversion_types)
 
     @property
@@ -117,7 +117,7 @@ class TSLPrimitiveTestCase:
     def __init__(self, case_data: TSLPrimitiveTestCaseData):
         self.__data: YamlDataType = case_data.data
         self.__lib_definitions: Dict[str, List[str]] = case_data.lib_definitions
-        self.__conversion_types: Dict[str, Dict[str, List[str]]] = case_data.conversion_types
+        self.__conversion_types: Dict[str, Dict[str, Dict[str, List[str]]]] = case_data.conversion_types
         self.__complete_tests_lib_definitions: Dict[str, List[str]] = case_data.complete_tests_lib_definitions
         self.__associated_primitive_class_name = case_data.class_name
         self.__associated_primitive_name = case_data.primitive_name

--- a/generator/static_files/core/simd/simd_primitive_concepts.yaml
+++ b/generator/static_files/core/simd/simd_primitive_concepts.yaml
@@ -4,14 +4,14 @@ includes:
    - '"../utils/type_concepts.hpp"'
 implementations:
    - |
-      
       #ifdef TSL_USE_CONCEPTS
-         template< typename T >
-         concept SimdPrimitiveImpl = requires {
-            { T::native_supported() } -> std::same_as< bool >;
-         } &&
-            ( T::native_supported() || (! T::native_supported() ) );
+          template<typename T>
+          concept SimdPrimitiveImpl = requires {
+              { T::native_supported() } -> std::same_as<bool>;
+          } && (
+              T::native_supported() || (! T::native_supported() ) 
+          );
       #else
-      #define SimdPrimitiveImpl class
+      #   define SimdPrimitiveImpl class
       #endif
 ...

--- a/generator/static_files/core/simd/simd_type.yaml
+++ b/generator/static_files/core/simd/simd_type.yaml
@@ -6,7 +6,7 @@ includes:
    - '"simd_type_concepts.hpp"'
    - "<array>"
 implementations:
-   - >
+    - |
       template<
             TSLArithmetic BaseType,
       #ifdef TSL_USE_CONCEPTS

--- a/generator/static_files/core/simd/simd_type_concepts.yaml
+++ b/generator/static_files/core/simd/simd_type_concepts.yaml
@@ -1,11 +1,10 @@
 ---
 file_description: "TODO."
 includes:
-   - '<type_traits>'
-   - '"../utils/type_concepts.hpp"'
+    - '<type_traits>'
+    - '"../utils/type_concepts.hpp"'
 implementations:
-   - |
-
+    - |
       #ifdef TSL_USE_CONCEPTS
          template<typename T, typename U>
          concept TargetExtension = TSLArithmetic<U> && requires {
@@ -41,14 +40,14 @@ implementations:
             ( T::vector_mask_ratio() > 0 ) &&
             ( T::mask_shift() > 0 );
       #else
-      #define VectorProcessingStyle class
+      #   define VectorProcessingStyle class
       #endif
-         struct native{};
-         struct workaround{};
+      struct native{};
+      struct workaround{};
       #ifdef TSL_USE_CONCEPTS
-         template<class T>
-         concept ImplementationDegreeOfFreedom = std::is_same_v<T, native> || std::is_same_v<T, workaround>;
+          template<class T>
+          concept ImplementationDegreeOfFreedom = std::is_same_v<T, native> || std::is_same_v<T, workaround>;
       #else
-      #define ImplementationDegreeOfFreedom class
+      #   define ImplementationDegreeOfFreedom class
       #endif
 ...

--- a/generator/static_files/core/tsl_static.yaml
+++ b/generator/static_files/core/tsl_static.yaml
@@ -1,10 +1,10 @@
 ---
 file_description: "Internal static header which includes all static headers."
 includes:
-   - '"utils/preprocessor.hpp"'
-   - '"utils/type_helper.hpp"'
-   - '"utils/type_concepts.hpp"'
-   - '"simd/simd_type_concepts.hpp"'
-   - '"simd/simd_type.hpp"'
-   - '"simd/simd_primitive_concepts.hpp"'
+    - '"utils/preprocessor.hpp"'
+    - '"utils/type_helper.hpp"'
+    - '"utils/type_concepts.hpp"'
+    - '"simd/simd_type_concepts.hpp"'
+    - '"simd/simd_type.hpp"'
+    - '"simd/simd_primitive_concepts.hpp"'
 ...

--- a/generator/static_files/core/tslintrin.yaml
+++ b/generator/static_files/core/tslintrin.yaml
@@ -2,8 +2,8 @@
 file_description: "General header which should be included to use the TSL."
 includes: ['"static/tsl_static.hpp"', '"generated/tsl_generated.hpp"']
 implementations:
-   - |
-      #ifndef TSL_GIT_VERSION_STR
-         #   define TSL_GIT_VERSION_STR "{{ git_version_str }}"
-         #endif
+  - |
+    #ifndef TSL_GIT_VERSION_STR
+    #   define TSL_GIT_VERSION_STR "{{ git_version_str }}"
+    #endif
 ...

--- a/generator/static_files/core/utils/preprocessor.yaml
+++ b/generator/static_files/core/utils/preprocessor.yaml
@@ -1,19 +1,19 @@
 ---
 file_description: "TODO."
 implementations:
-   - |
+    - |
       #ifndef TSL_FORCE_INLINE
-      #  if defined(__clang__) || defined(__GNUC__)
-      #    define TSL_FORCE_INLINE inline __attribute__((always_inline))
-      #  elif defined(_MSC_VER)
-      #    define TSL_FORCE_INLINE inline __forceinline
-      #  endif
+      #   if defined(__clang__) || defined(__GNUC__)
+      #       define TSL_FORCE_INLINE inline __attribute__((always_inline))
+      #   elif defined(_MSC_VER)
+      #       define TSL_FORCE_INLINE inline __forceinline
+      #   endif
       #endif
       #ifndef TSL_NO_NATIVE_SUPPORT_WARNING
       #   define TSL_NO_NATIVE_SUPPORT_WARNING [[deprecated("This primitive is not supported by your hardware natively. Thus, a workaround is used.")]]
       #endif
       #ifndef TSL_DEP_TYPE
-      #   define TSL_DEP_TYPE(CONDITION, IFBRANCH, ELSEBRANCH) std::conditional_t< CONDITION, IFBRANCH, ELSEBRANCH >
+      #   define TSL_DEP_TYPE(CONDITION, IFBRANCH, ELSEBRANCH) std::conditional_t<CONDITION, IFBRANCH, ELSEBRANCH>
       #endif
       #ifndef TSL_CVAL
       #   define TSL_CVAL(type, value) std::integral_constant<type,value>{}

--- a/generator/static_files/core/utils/type_concepts.yaml
+++ b/generator/static_files/core/utils/type_concepts.yaml
@@ -1,19 +1,18 @@
 ---
 file_description: "TODO."
 includes:
-   - '"type_helper.hpp"'
+    - '"type_helper.hpp"'
 implementations:
-   - |
-      
+    - |
       #ifdef TSL_USE_CONCEPTS
-         #include <concepts> //this is ugly, but the generator does not support conditional includes
-         template< typename T >
-         concept TSLArithmetic = std::is_arithmetic_v< T >;
+      #   include <concepts> //this is ugly, but the generator does not support conditional includes
+          template<typename T>
+          concept TSLArithmetic = std::is_arithmetic_v<T>;
 
-         template< typename T >
-         concept TSL_Tuple = is_tuple< T >::value;
+          template<typename T>
+          concept TSL_Tuple = is_tuple<T>::value;
       #else
-      #define TSLArithmetic typename
-      #define TSL_Tuple typename
+      #   define TSLArithmetic typename
+      #   define TSL_Tuple typename
       #endif
 ...

--- a/generator/static_files/core/utils/type_helper.yaml
+++ b/generator/static_files/core/utils/type_helper.yaml
@@ -87,4 +87,17 @@ implementations:
         using std::assume_aligned;
     #endif
   
+  - |
+    template<bool is_signed, std::size_t bit_width> struct integral_type;
+    
+    template<bool is_signed, std::size_t bit_width>
+    using integral_type_t = typename integral_type<is_signed, bit_width>::type;
+    
+    template<std::size_t bit_width>
+    struct integral_type<true, bit_width> { using type = std::make_signed_t<integral_type_t<false, bit_width>>; };
+    
+    template<> struct integral_type<false, 8> { using type = std::uint8_t; };
+    template<> struct integral_type<false, 16> { using type = std::uint16_t; };
+    template<> struct integral_type<false, 32> { using type = std::uint32_t; };
+    template<> struct integral_type<false, 64> { using type = std::uint64_t; };
 ...

--- a/generator/static_files/core/utils/type_helper.yaml
+++ b/generator/static_files/core/utils/type_helper.yaml
@@ -1,89 +1,90 @@
 ---
 file_description: "TODO."
 includes:
-   - '<cstddef>'
-   - '<type_traits>'
-   - '<typeinfo>'
-   - '<cxxabi.h>'
-   - '<memory>'
-   - '<string>'
-   - '<cstdlib>'
-   - '<limits>'
-   - '<iostream>'
+  - '<cstddef>'
+  - '<type_traits>'
+  - '<typeinfo>'
+  - '<cxxabi.h>'
+  - '<memory>'
+  - '<string>'
+  - '<cstdlib>'
+  - '<limits>'
+  - '<iostream>'
 implementations:
-   - >
-      enum class modifier {
-              HEX,
-              DEC,
-              OCT,
-              BIN
-      };
-   - >
-      template< class T >
-         std::string type_name( ) {
-            typedef typename std::remove_reference< T >::type TR;
-            std::unique_ptr< char, void ( * )( void * ) > own (
-               abi::__cxa_demangle( typeid( TR ).name( ), nullptr,nullptr, nullptr ),
-               std::free
-            );
-            std::string r = own != nullptr ? own.get( ) : typeid( TR ).name( );
-            if( std::is_const< TR >::value ) {
-               r += " const";
+  - |
+    enum class modifier {
+        HEX,
+        DEC,
+        OCT,
+        BIN
+    };
+    
+  - |
+    template<class T>
+    std::string type_name( ) {
+        typedef typename std::remove_reference<T>::type TR;
+        std::unique_ptr<char, void (*)(void *)> own (
+            abi::__cxa_demangle( typeid( TR ).name(), nullptr,nullptr, nullptr ),
+            std::free
+        );
+        std::string r = own != nullptr ? own.get() : typeid( TR ).name();
+        if(std::is_const<TR>::value) {
+            r += " const";
+        }
+        if (std::is_volatile<TR>::value) {
+            r += " volatile";
             }
-            if( std::is_volatile< TR >::value ) {
-               r += " volatile";
-               }
-            if( std::is_lvalue_reference< T >::value ) {
-               r += "&";
-            } else if( std::is_rvalue_reference< T >::value ) {
-               r += "&&";
+        if (std::is_lvalue_reference<T>::value) {
+            r += "&";
+        } else if(std::is_rvalue_reference<T>::value) {
+            r += "&&";
+        }
+        return r;
+    }
+    #define TYPENAME(x) type_name<decltype(x)>()
+         
+  - |
+    template<typename T>
+    struct is_tuple_impl : std::false_type { };   
+    
+    template<typename... Ts>
+    struct is_tuple_impl<std::tuple<Ts...>> : std::true_type {};
+    
+    template<typename T>
+    struct is_tuple : is_tuple_impl<std::remove_cv_t<T>> {};
+
+  - "using offset_t = std::size_t;"
+  - "constexpr unsigned cilog2(unsigned val) { return val ? 1 + cilog2(val >> 1) : -1; }"
+  - |
+    #ifndef __cpp_lib_assume_aligned
+        //c++20-standard - copied source from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1007r1.pdf
+        template<std::size_t N, typename T>
+        constexpr T* assume_aligned(T* ptr) noexcept {
+    #   if defined(__clang__) || (defined(__GNUC__) && !defined(__ICC))
+            return reinterpret_cast<T*>(__builtin_assume_aligned(ptr, N));
+    #   elif defined(_MSC_VER)
+            if ((reinterpret_cast<std::uintptr_t>(ptr) & ((1 << N) - 1)) == 0) {
+                return ptr;
+            } else {
+                __assume(0);
             }
-            return r;
-         }
-         #define TYPENAME( x ) type_name< decltype( x ) >( )
-
-   - >
-      template< typename T >
-         struct is_tuple_impl : std::false_type { };   
-         template< typename... Ts >
-         struct is_tuple_impl< std::tuple< Ts... > > : std::true_type { };
-         template< typename T >
-         struct is_tuple : is_tuple_impl< std::remove_cv_t< T > > { };
-
-   - "using offset_t = std::size_t;"
-   - "constexpr unsigned cilog2(unsigned val) { return val ? 1 + cilog2(val >> 1) : -1; }"
-   - |
-      #ifndef __cpp_lib_assume_aligned
-      //c++20-standard - copied source from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1007r1.pdf
-      template<std::size_t N, typename T>
-      constexpr T* assume_aligned(T* ptr) noexcept {
-      #  if defined(__clang__) || (defined(__GNUC__) && !defined(__ICC))
-         return reinterpret_cast<T*>(__builtin_assume_aligned(ptr, N));
-      #  elif defined(_MSC_VER)
-         if ((reinterpret_cast<std::uintptr_t>(ptr) & ((1 << N) - 1)) == 0) {
+    #   elif defined(__ICC)
+            switch (N) {
+                case 2: __assume_aligned(ptr, 2); break;
+                case 4: __assume_aligned(ptr, 4); break;
+                case 8: __assume_aligned(ptr, 8); break;
+                case 16: __assume_aligned(ptr, 16); break;
+                case 32: __assume_aligned(ptr, 32); break;
+                case 64: __assume_aligned(ptr, 64); break;
+                case 128: __assume_aligned(ptr, 128); break;
+            }
             return ptr;
-         } else {
-            __assume(0);
-         }
-      #  elif defined(__ICC)
-         switch (N) {
-            case 2: __assume_aligned(ptr, 2); break;
-            case 4: __assume_aligned(ptr, 4); break;
-            case 8: __assume_aligned(ptr, 8); break;
-            case 16: __assume_aligned(ptr, 16); break;
-            case 32: __assume_aligned(ptr, 32); break;
-            case 64: __assume_aligned(ptr, 64); break;
-            case 128: __assume_aligned(ptr, 128); break;
-         }
-         return ptr;
-      #  else
-         return ptr;
-      #  endif
-      }
-      #else
-         using std::assume_aligned;
-      #endif
-
-
-
+    #   else
+            return ptr;
+    #   endif
+    }
+    #else
+        using std::assume_aligned;
+    #endif
+  
 ...

--- a/generator/static_files/expansions/tests/test_functions.yaml
+++ b/generator/static_files/expansions/tests/test_functions.yaml
@@ -13,22 +13,29 @@ includes:
    - "<limits>"
    - '"catch.hpp"'
 implementations:
-   - |
+  - |
       template<typename T>
-      void rnd_init(T* data, std::size_t element_count) {
+      void rnd_init_bounded(
+          T* data, std::size_t element_count, T min_inclusive, T max_inclusive
+      ) {
           std::mt19937 engine(std::chrono::high_resolution_clock::now().time_since_epoch().count());
           using dist_type = std::conditional_t< std::is_floating_point_v<T>, std::uniform_real_distribution<T>, std::uniform_int_distribution<T>>;
-          T max = std::clamp<T>(
-                            static_cast<T>(1000),
-                            static_cast<T>(0),
-                            static_cast<T>(std::numeric_limits<T>::max() / 3)
-                        );
-          dist_type dist(static_cast<T>(0), max);
+          dist_type dist(min_inclusive, max_inclusive);
           for(std::size_t i = 0; i < element_count; ++i) {
             data[i] = dist(engine);
           }
       }
-   - |
+  - |
+    template<typename T>
+    void rnd_init(T* data, std::size_t element_count) {
+        rnd_init_bounded(
+            data, 
+            element_count, 
+            static_cast<T>(0), 
+            std::clamp<T>(static_cast<T>(1000), static_cast<T>(0), static_cast<T>(std::numeric_limits<T>::max() / 3))
+        );
+    }
+  - |
       template<typename T>
       void alternate_init_no_zero(T* data, std::size_t element_count) {
           T max =
@@ -57,14 +64,14 @@ implementations:
             }
           }
       }
-   - |
+  - |
       template<typename T>
       void seq_init_start_0(T* data, std::size_t element_count) {
           for(std::size_t i = 0; i < element_count; ++i) {
             data[i] = i;
           }
       }
-   - |
+  - |
       template<typename T>
       void seq_init_start_low(T* data, std::size_t element_count) {
           T current_value = std::numeric_limits<T>::lowest();
@@ -72,7 +79,7 @@ implementations:
             data[i] = current_value++;
           }
       }
-   - |
+  - |
       template<typename T>
       void seq_init(T* data, std::size_t element_count, T start) {
           T current_value = start;
@@ -81,7 +88,7 @@ implementations:
             current_value = current_value + (T)1;
           }
       }
-   - |
+  - |
       template<typename T>
       bool check_value(T base, T to_be_examined) {
           if constexpr(std::is_integral_v<T>) {
@@ -99,7 +106,7 @@ implementations:
             return (std::fabs(static_cast<T>(base - to_be_examined)) <= std::numeric_limits<T>::epsilon());
           }
       }
-   - |
+  - |
       template<VectorProcessingStyle Vec>
       class set_call_helper_t {
           private:
@@ -112,7 +119,7 @@ implementations:
                 return call_set_impl(data, std::make_index_sequence<Vec::vector_element_count()>{});
             }
       };
-   - |
+  - |
       template<VectorProcessingStyle Vec>
       class test_memory_helper_t {
           public:
@@ -136,9 +143,9 @@ implementations:
                 m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
             { 
                 
-              }
+            }
             template<typename... Ts>
-            test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*,std::size_t)> const & fun = rnd_init<base_t>, Ts... init_args):
+            test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*,std::size_t, Ts...)> const & fun = rnd_init<base_t>, Ts... init_args):
                 m_data_element_count   {p_data_element_count},
                 m_result_count         {p_result_count},
                 m_data_ref             {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_data_element_count*sizeof(base_t))},
@@ -149,19 +156,6 @@ implementations:
             {
                 fun(m_data_ref, p_data_element_count, init_args...);
                 tsl::memory_cp<Vec>(m_data_target, m_data_ref, p_data_element_count*sizeof(base_t), 1);
-            }
-            template<typename... Ts>
-            test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*,std::size_t, base_t)> const & fun, base_t start):
-              m_data_element_count   {p_data_element_count},
-              m_result_count         {p_result_count},
-              m_data_ref             {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_data_element_count*sizeof(base_t))},
-              m_data_target          {(aligned) ? tsl::allocate_aligned<Vec>(p_data_element_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_data_element_count*sizeof(base_t))},
-              m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
-              m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
-              m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
-            {
-              fun(m_data_ref, p_data_element_count, start);
-              tsl::memory_cp<Vec>(m_data_target, m_data_ref, p_data_element_count*sizeof(base_t), 1);
             }
             virtual ~test_memory_helper_t() {
                 tsl::deallocate<Vec>(m_result_target);

--- a/generator/static_files/expansions/tests/test_functions.yaml
+++ b/generator/static_files/expansions/tests/test_functions.yaml
@@ -29,9 +29,9 @@ implementations:
     template<typename T>
     void rnd_init(T* data, std::size_t element_count) {
         rnd_init_bounded(
-            data, 
-            element_count, 
-            static_cast<T>(0), 
+            data,
+            element_count,
+            static_cast<T>(0),
             std::clamp<T>(static_cast<T>(1000), static_cast<T>(0), static_cast<T>(std::numeric_limits<T>::max() / 3))
         );
     }
@@ -102,7 +102,7 @@ implementations:
                 return (std::abs(static_cast<T>(base - to_be_examined)) == std::numeric_limits<T>::epsilon());
             }
           } else {
-            if (std::isnan(base)) return std::isnan(to_be_examined); 
+            if (std::isnan(base)) return std::isnan(to_be_examined);
             return (std::fabs(static_cast<T>(base - to_be_examined)) <= std::numeric_limits<T>::epsilon());
           }
       }
@@ -141,11 +141,23 @@ implementations:
                 m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
                 m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
                 m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
-            { 
-                
+            {
+
+            }
+            test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*, std::size_t)> const& fun = rnd_init<typename Vec::base_type>):
+                m_data_element_count   {p_data_element_count},
+                m_result_count         {p_result_count},
+                m_data_ref             {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_data_element_count*sizeof(base_t))},
+                m_data_target          {(aligned) ? tsl::allocate_aligned<Vec>(p_data_element_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_data_element_count*sizeof(base_t))},
+                m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
+                m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
+                m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
+            {
+                fun(m_data_ref, p_data_element_count);
+                tsl::memory_cp<Vec>(m_data_target, m_data_ref, p_data_element_count*sizeof(base_t), 1);
             }
             template<typename... Ts>
-            test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*,std::size_t, Ts...)> const & fun = rnd_init<base_t>, Ts... init_args):
+            test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, void (*fun)(base_t*, std::size_t, Ts...), Ts... init_args):
                 m_data_element_count   {p_data_element_count},
                 m_result_count         {p_result_count},
                 m_data_ref             {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_data_element_count*sizeof(base_t))},

--- a/generator/static_files/expansions/tests/test_functions.yaml
+++ b/generator/static_files/expansions/tests/test_functions.yaml
@@ -15,198 +15,198 @@ includes:
 implementations:
    - |
       template<typename T>
-            void rnd_init(T* data, std::size_t element_count) {
-               std::mt19937 engine(std::chrono::high_resolution_clock::now().time_since_epoch().count());
-               using dist_type = std::conditional_t< std::is_floating_point_v<T>, std::uniform_real_distribution<T>, std::uniform_int_distribution<T>>;
-               T max = std::clamp<T>(
-                                 static_cast<T>(1000),
-                                 static_cast<T>(0),
-                                 static_cast<T>(std::numeric_limits<T>::max() / 3)
-                              );
-               dist_type dist(static_cast<T>(0), max);
-               for(std::size_t i = 0; i < element_count; ++i) {
-                  data[i] = dist(engine);
-               }
-            }
+      void rnd_init(T* data, std::size_t element_count) {
+          std::mt19937 engine(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+          using dist_type = std::conditional_t< std::is_floating_point_v<T>, std::uniform_real_distribution<T>, std::uniform_int_distribution<T>>;
+          T max = std::clamp<T>(
+                            static_cast<T>(1000),
+                            static_cast<T>(0),
+                            static_cast<T>(std::numeric_limits<T>::max() / 3)
+                        );
+          dist_type dist(static_cast<T>(0), max);
+          for(std::size_t i = 0; i < element_count; ++i) {
+            data[i] = dist(engine);
+          }
+      }
    - |
       template<typename T>
-            void alternate_init_no_zero(T* data, std::size_t element_count) {
-               T max =
-                  static_cast<T>(
-                     std::clamp<size_t>(
-                        element_count,
-                        static_cast<size_t>(std::numeric_limits<T>::lowest()),
-                        static_cast<size_t>(std::numeric_limits<T>::max())
-                     )
-                  );
-               T val = (T)1;
-               size_t pos = 0;
-               for(size_t i = 0; i < element_count/2; ++i) {
-                  data[pos++] = val;
-                  if constexpr (std::is_signed_v<T>) {
-                      data[pos++] = -val;
-                     if constexpr (std::is_floating_point_v<T>) {
-                        ++val;
-                     } else {
-                        val = (++val%max) == 0 ? 1 : val;
-                     }
-                  } else {
-                     val = (++val%max) == 0 ? 1 : val;
-                     data[pos++] = val;
-                     val = (++val%max) == 0 ? 1 : val;
-                  }
-               }
+      void alternate_init_no_zero(T* data, std::size_t element_count) {
+          T max =
+            static_cast<T>(
+                std::clamp<size_t>(
+                  element_count,
+                  static_cast<size_t>(std::numeric_limits<T>::lowest()),
+                  static_cast<size_t>(std::numeric_limits<T>::max())
+                )
+            );
+          T val = (T)1;
+          size_t pos = 0;
+          for(size_t i = 0; i < element_count/2; ++i) {
+            data[pos++] = val;
+            if constexpr (std::is_signed_v<T>) {
+                data[pos++] = -val;
+                if constexpr (std::is_floating_point_v<T>) {
+                  ++val;
+                } else {
+                  val = (++val%max) == 0 ? 1 : val;
+                }
+            } else {
+                val = (++val%max) == 0 ? 1 : val;
+                data[pos++] = val;
+                val = (++val%max) == 0 ? 1 : val;
             }
+          }
+      }
    - |
       template<typename T>
-            void seq_init_start_0(T* data, std::size_t element_count) {
-               for(std::size_t i = 0; i < element_count; ++i) {
-                  data[i] = i;
-               }
-            }
+      void seq_init_start_0(T* data, std::size_t element_count) {
+          for(std::size_t i = 0; i < element_count; ++i) {
+            data[i] = i;
+          }
+      }
    - |
       template<typename T>
-            void seq_init_start_low(T* data, std::size_t element_count) {
-               T current_value = std::numeric_limits<T>::lowest();
-               for(std::size_t i = 0; i < element_count; ++i) {
-                  data[i] = current_value++;
-               }
-            }
+      void seq_init_start_low(T* data, std::size_t element_count) {
+          T current_value = std::numeric_limits<T>::lowest();
+          for(std::size_t i = 0; i < element_count; ++i) {
+            data[i] = current_value++;
+          }
+      }
    - |
       template<typename T>
-            void seq_init(T* data, std::size_t element_count, T start) {
-               T current_value = start;
-               for(std::size_t i = 0; i < element_count; ++i) {
-                  data[i] = current_value;
-                  current_value = current_value + (T)1;
-               }
-            }
+      void seq_init(T* data, std::size_t element_count, T start) {
+          T current_value = start;
+          for(std::size_t i = 0; i < element_count; ++i) {
+            data[i] = current_value;
+            current_value = current_value + (T)1;
+          }
+      }
    - |
       template<typename T>
-            bool check_value(T base, T to_be_examined) {
-               if constexpr(std::is_integral_v<T>) {
-                  if constexpr(std::is_unsigned_v<T>) {
-                     if(base >= to_be_examined) {
-                        return ((base - to_be_examined) == std::numeric_limits<T>::epsilon());
-                     } else {
-                        return ((to_be_examined - base) == std::numeric_limits<T>::epsilon());
-                     }
-                  } else {
-                     return (std::abs(static_cast<T>(base - to_be_examined)) == std::numeric_limits<T>::epsilon());
-                  }
-               } else {
-                  if (std::isnan(base)) return std::isnan(to_be_examined); 
-                  return (std::fabs(static_cast<T>(base - to_be_examined)) <= std::numeric_limits<T>::epsilon());
-               }
+      bool check_value(T base, T to_be_examined) {
+          if constexpr(std::is_integral_v<T>) {
+            if constexpr(std::is_unsigned_v<T>) {
+                if(base >= to_be_examined) {
+                  return ((base - to_be_examined) == std::numeric_limits<T>::epsilon());
+                } else {
+                  return ((to_be_examined - base) == std::numeric_limits<T>::epsilon());
+                }
+            } else {
+                return (std::abs(static_cast<T>(base - to_be_examined)) == std::numeric_limits<T>::epsilon());
             }
+          } else {
+            if (std::isnan(base)) return std::isnan(to_be_examined); 
+            return (std::fabs(static_cast<T>(base - to_be_examined)) <= std::numeric_limits<T>::epsilon());
+          }
+      }
    - |
       template<VectorProcessingStyle Vec>
-            class set_call_helper_t {
-               private:
-                  template<std::size_t... Is>
-                  static auto call_set_impl(typename Vec::base_type const * data, std::index_sequence<Is...>) {
-                     return tsl::set<Vec>(data[(Vec::vector_element_count()-1)-Is]...);
-                  }
-               public:
-                  static auto call_set(typename Vec::base_type const * data) {
-                     return call_set_impl(data, std::make_index_sequence<Vec::vector_element_count()>{});
-                  }
-            };
+      class set_call_helper_t {
+          private:
+            template<std::size_t... Is>
+            static auto call_set_impl(typename Vec::base_type const * data, std::index_sequence<Is...>) {
+                return tsl::set<Vec>(data[(Vec::vector_element_count()-1)-Is]...);
+            }
+          public:
+            static auto call_set(typename Vec::base_type const * data) {
+                return call_set_impl(data, std::make_index_sequence<Vec::vector_element_count()>{});
+            }
+      };
    - |
       template<VectorProcessingStyle Vec>
-            class test_memory_helper_t {
-               public:
-                  using base_t = typename Vec::base_type;
-               private:
-                  std::size_t const m_data_element_count;
-                  std::size_t const m_result_count;
-                  base_t * const m_data_ref;
-                  base_t * const m_data_target;
-                  base_t * const m_result_ref;
-                  base_t * const m_result_target_for_ref;
-                  base_t * const m_result_target;
-               public:
-                  explicit test_memory_helper_t(std::size_t p_result_count, bool aligned):
-                     m_data_element_count   {0},
-                     m_result_count         {p_result_count},
-                     m_data_ref             {nullptr},
-                     m_data_target          {nullptr},
-                     m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
-                     m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
-                     m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
-                  { 
-                     
-                   }
-                  template<typename... Ts>
-                  test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*,std::size_t)> const & fun = rnd_init<base_t>, Ts... init_args):
-                     m_data_element_count   {p_data_element_count},
-                     m_result_count         {p_result_count},
-                     m_data_ref             {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_data_element_count*sizeof(base_t))},
-                     m_data_target          {(aligned) ? tsl::allocate_aligned<Vec>(p_data_element_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_data_element_count*sizeof(base_t))},
-                     m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
-                     m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
-                     m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
-                  {
-                     fun(m_data_ref, p_data_element_count, init_args...);
-                     tsl::memory_cp<Vec>(m_data_target, m_data_ref, p_data_element_count*sizeof(base_t), 1);
-                  }
-                  template<typename... Ts>
-                  test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*,std::size_t, base_t)> const & fun, base_t start):
-                    m_data_element_count   {p_data_element_count},
-                    m_result_count         {p_result_count},
-                    m_data_ref             {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_data_element_count*sizeof(base_t))},
-                    m_data_target          {(aligned) ? tsl::allocate_aligned<Vec>(p_data_element_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_data_element_count*sizeof(base_t))},
-                    m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
-                    m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
-                    m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
-                  {
-                    fun(m_data_ref, p_data_element_count, start);
-                    tsl::memory_cp<Vec>(m_data_target, m_data_ref, p_data_element_count*sizeof(base_t), 1);
-                  }
-                  virtual ~test_memory_helper_t() {
-                     tsl::deallocate<Vec>(m_result_target);
-                     tsl::deallocate<tsl::simd<base_t, tsl::scalar>>(m_result_target_for_ref);
-                     tsl::deallocate<tsl::simd<base_t, tsl::scalar>>(m_result_ref);
-                     if(m_data_element_count > 0) {
-                        tsl::deallocate<Vec>(m_data_target);
-                        tsl::deallocate<tsl::simd<base_t, tsl::scalar>>(m_data_ref);
-                     }
-                  }
-               public:
-                  auto data_ref() const { return m_data_ref; }
-                  auto data_target() const { return m_data_target; }
-                  auto result_ref() { return m_result_ref; }
-                  auto result_target() { return m_result_target; }
-               public:
-                  void ship_to_dev() {
-                     tsl::memory_cp<Vec>(m_data_target, m_data_ref, m_data_element_count*sizeof(base_t), 1);
-                  }
-                  void synchronize() {
-                     tsl::memory_cp<Vec>(m_result_target_for_ref, m_result_target, m_result_count*sizeof(base_t), 2);
-                  }
-                  bool validate() const {
-                     bool result = true;
-                     for(auto i = 0; i < m_result_count; ++i) {
-                        result &= check_value<base_t>(m_result_ref[i], m_result_target_for_ref[i]);
-                     }
-                     return result;
-                  }
-                  bool validate_simd_register(typename Vec::register_type reg) const {
-                     auto tmp_target_buf = tsl::allocate_aligned<Vec>(Vec::vector_size_B(), Vec::vector_alignment());
-                     auto tmp_reference_buf = tsl::allocate<tsl::simd<base_t, tsl::scalar>>(Vec::vector_size_B());
-                     if constexpr(Vec::register_type_is_pointer_v) {
-                        tsl::memory_cp<Vec>(tmp_target_buf, reinterpret_cast<typename Vec::base_type const *>(reg), Vec::vector_size_B(), 3);
-                     } else {
-                        tsl::memory_cp<Vec>(tmp_target_buf, reinterpret_cast<typename Vec::base_type const *>(&reg), Vec::vector_size_B(), 3);
-                     }
-                     tsl::memory_cp<Vec>(tmp_reference_buf, tmp_target_buf, Vec::vector_size_B(), 2);
-                     bool result = true;
-                     for(auto i = 0; i < Vec::vector_element_count(); ++i) {
-                        result &= check_value<base_t>(tmp_reference_buf[i], m_result_ref[i]);
-                     }
-                     tsl::deallocate<tsl::simd<base_t, tsl::scalar>>(tmp_reference_buf);
-                     tsl::deallocate<Vec>(tmp_target_buf);
-                     return result;
-                  }
-            };
+      class test_memory_helper_t {
+          public:
+            using base_t = typename Vec::base_type;
+          private:
+            std::size_t const m_data_element_count;
+            std::size_t const m_result_count;
+            base_t * const m_data_ref;
+            base_t * const m_data_target;
+            base_t * const m_result_ref;
+            base_t * const m_result_target_for_ref;
+            base_t * const m_result_target;
+          public:
+            explicit test_memory_helper_t(std::size_t p_result_count, bool aligned):
+                m_data_element_count   {0},
+                m_result_count         {p_result_count},
+                m_data_ref             {nullptr},
+                m_data_target          {nullptr},
+                m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
+                m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
+                m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
+            { 
+                
+              }
+            template<typename... Ts>
+            test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*,std::size_t)> const & fun = rnd_init<base_t>, Ts... init_args):
+                m_data_element_count   {p_data_element_count},
+                m_result_count         {p_result_count},
+                m_data_ref             {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_data_element_count*sizeof(base_t))},
+                m_data_target          {(aligned) ? tsl::allocate_aligned<Vec>(p_data_element_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_data_element_count*sizeof(base_t))},
+                m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
+                m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
+                m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
+            {
+                fun(m_data_ref, p_data_element_count, init_args...);
+                tsl::memory_cp<Vec>(m_data_target, m_data_ref, p_data_element_count*sizeof(base_t), 1);
+            }
+            template<typename... Ts>
+            test_memory_helper_t(std::size_t p_data_element_count, std::size_t p_result_count, bool aligned, std::function<void(base_t*,std::size_t, base_t)> const & fun, base_t start):
+              m_data_element_count   {p_data_element_count},
+              m_result_count         {p_result_count},
+              m_data_ref             {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_data_element_count*sizeof(base_t))},
+              m_data_target          {(aligned) ? tsl::allocate_aligned<Vec>(p_data_element_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_data_element_count*sizeof(base_t))},
+              m_result_ref           {tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
+              m_result_target_for_ref{tsl::allocate<tsl::simd<base_t, tsl::scalar>>(p_result_count*sizeof(base_t))},
+              m_result_target        {(aligned) ? tsl::allocate_aligned<Vec>(p_result_count*sizeof(base_t), Vec::vector_alignment()) : tsl::allocate<Vec>(p_result_count*sizeof(base_t))}
+            {
+              fun(m_data_ref, p_data_element_count, start);
+              tsl::memory_cp<Vec>(m_data_target, m_data_ref, p_data_element_count*sizeof(base_t), 1);
+            }
+            virtual ~test_memory_helper_t() {
+                tsl::deallocate<Vec>(m_result_target);
+                tsl::deallocate<tsl::simd<base_t, tsl::scalar>>(m_result_target_for_ref);
+                tsl::deallocate<tsl::simd<base_t, tsl::scalar>>(m_result_ref);
+                if(m_data_element_count > 0) {
+                  tsl::deallocate<Vec>(m_data_target);
+                  tsl::deallocate<tsl::simd<base_t, tsl::scalar>>(m_data_ref);
+                }
+            }
+          public:
+            auto data_ref() const { return m_data_ref; }
+            auto data_target() const { return m_data_target; }
+            auto result_ref() { return m_result_ref; }
+            auto result_target() { return m_result_target; }
+          public:
+            void ship_to_dev() {
+                tsl::memory_cp<Vec>(m_data_target, m_data_ref, m_data_element_count*sizeof(base_t), 1);
+            }
+            void synchronize() {
+                tsl::memory_cp<Vec>(m_result_target_for_ref, m_result_target, m_result_count*sizeof(base_t), 2);
+            }
+            bool validate() const {
+                bool result = true;
+                for(auto i = 0; i < m_result_count; ++i) {
+                  result &= check_value<base_t>(m_result_ref[i], m_result_target_for_ref[i]);
+                }
+                return result;
+            }
+            bool validate_simd_register(typename Vec::register_type reg) const {
+                auto tmp_target_buf = tsl::allocate_aligned<Vec>(Vec::vector_size_B(), Vec::vector_alignment());
+                auto tmp_reference_buf = tsl::allocate<tsl::simd<base_t, tsl::scalar>>(Vec::vector_size_B());
+                if constexpr(Vec::register_type_is_pointer_v) {
+                  tsl::memory_cp<Vec>(tmp_target_buf, reinterpret_cast<typename Vec::base_type const *>(reg), Vec::vector_size_B(), 3);
+                } else {
+                  tsl::memory_cp<Vec>(tmp_target_buf, reinterpret_cast<typename Vec::base_type const *>(&reg), Vec::vector_size_B(), 3);
+                }
+                tsl::memory_cp<Vec>(tmp_reference_buf, tmp_target_buf, Vec::vector_size_B(), 2);
+                bool result = true;
+                for(auto i = 0; i < Vec::vector_element_count(); ++i) {
+                  result &= check_value<base_t>(tmp_reference_buf[i], m_result_ref[i]);
+                }
+                tsl::deallocate<tsl::simd<base_t, tsl::scalar>>(tmp_reference_buf);
+                tsl::deallocate<Vec>(tmp_target_buf);
+                return result;
+            }
+      };
 ...

--- a/primitive_data/primitives/convert.yaml
+++ b/primitive_data/primitives/convert.yaml
@@ -4,7 +4,8 @@ description: "Conversion primitives."
 ...
 ---
 primitive_name: "reinterpret"
-additional_simd_template_parameter: "ToType"
+additional_simd_template_parameter: 
+  name: "ToType"
 parameters:
   - ctype: "const typename Vec::register_type"
     name: "data"
@@ -153,7 +154,8 @@ definitions:
 ...
 ---
 primitive_name: "cast"
-additional_simd_template_parameter: "ToType"
+additional_simd_template_parameter: 
+  name: "ToType"
 parameters:
   - ctype: "const typename Vec::register_type"
     name: "data"
@@ -245,7 +247,8 @@ definitions:
 ---
 # TODO(cmrs): add more implementations here
 primitive_name: "split"
-additional_simd_template_parameter: "ToType"
+additional_simd_template_parameter: 
+  name: "ToType"
 parameters:
   - ctype: "const typename Vec::register_type"
     name: "data"
@@ -281,7 +284,8 @@ definitions:
 ---
 # TODO(cmrs): add more implementations here
 primitive_name: "merge"
-additional_simd_template_parameter: "ToType"
+additional_simd_template_parameter: 
+  name: "ToType"
 parameters:
   - ctype: "std::array<typename Vec::register_type, sizeof(typename Vec::base_type)/sizeof(typename ToType::base_type) * ToType::vector_element_count() / Vec::vector_element_count()>"
     name: "data"
@@ -304,7 +308,8 @@ definitions:
 ...
 ---
 primitive_name: "convert_up"
-additional_simd_template_parameter: "ToType"
+additional_simd_template_parameter: 
+  name: "ToType"
 parameters:
   - ctype: "const typename Vec::register_type"
     name: "data"
@@ -698,7 +703,8 @@ definitions:
 ...
 ---
 primitive_name: "convert_down"
-additional_simd_template_parameter: "ToType"
+additional_simd_template_parameter: 
+  name: "ToType"
 parameters:
   - ctype: "std::array<typename Vec::register_type, sizeof(typename Vec::base_type)/sizeof(typename ToType::base_type)>"
     name: "data"

--- a/primitive_data/primitives/convert.yaml
+++ b/primitive_data/primitives/convert.yaml
@@ -4,7 +4,7 @@ description: "Conversion primitives."
 ...
 ---
 primitive_name: "reinterpret"
-additional_simd_template_parameter: 
+additional_simd_template_parameter:
   name: "ToType"
 parameters:
   - ctype: "const typename Vec::register_type"
@@ -154,7 +154,7 @@ definitions:
 ...
 ---
 primitive_name: "cast"
-additional_simd_template_parameter: 
+additional_simd_template_parameter:
   name: "ToType"
 parameters:
   - ctype: "const typename Vec::register_type"
@@ -247,7 +247,7 @@ definitions:
 ---
 # TODO(cmrs): add more implementations here
 primitive_name: "split"
-additional_simd_template_parameter: 
+additional_simd_template_parameter:
   name: "ToType"
 parameters:
   - ctype: "const typename Vec::register_type"
@@ -284,7 +284,7 @@ definitions:
 ---
 # TODO(cmrs): add more implementations here
 primitive_name: "merge"
-additional_simd_template_parameter: 
+additional_simd_template_parameter:
   name: "ToType"
 parameters:
   - ctype: "std::array<typename Vec::register_type, sizeof(typename Vec::base_type)/sizeof(typename ToType::base_type) * ToType::vector_element_count() / Vec::vector_element_count()>"
@@ -308,7 +308,7 @@ definitions:
 ...
 ---
 primitive_name: "convert_up"
-additional_simd_template_parameter: 
+additional_simd_template_parameter:
   name: "ToType"
 parameters:
   - ctype: "const typename Vec::register_type"
@@ -703,7 +703,7 @@ definitions:
 ...
 ---
 primitive_name: "convert_down"
-additional_simd_template_parameter: 
+additional_simd_template_parameter:
   name: "ToType"
 parameters:
   - ctype: "std::array<typename Vec::register_type, sizeof(typename Vec::base_type)/sizeof(typename ToType::base_type)>"

--- a/primitive_data/primitives/ls.yaml
+++ b/primitive_data/primitives/ls.yaml
@@ -6,7 +6,7 @@ description: "Load/Store primitives"
 primitive_name: "load"
 brief_description: "Loads data from aligned memory into a vector register."
 parameters:
-  - ctype: "const typename Vec::base_type *"
+  - ctype: "const typename Vec::base_type*"
     name: "memory"
     description: "Aligned memory which should be transferred into a vector register."
 returns:
@@ -95,7 +95,7 @@ definitions:
 primitive_name: "loadu"
 brief_description: "Loads data from (un)aligned memory into a vector register."
 parameters:
-  - ctype: "const typename Vec::base_type *"
+  - ctype: "const typename Vec::base_type*"
     name: "memory"
     description: "(Un)aligned memory which should be transferred into a vector register."
 returns:
@@ -183,7 +183,7 @@ definitions:
 primitive_name: "store"
 brief_description: "Stores data from a vector register to aligned memory."
 parameters:
-  - ctype: "typename Vec::base_type *"
+  - ctype: "typename Vec::base_type*"
     name: "memory"
     description: "Aligned memory where the data should be stored into."
   - ctype: "const typename Vec::register_type"
@@ -216,11 +216,11 @@ definitions:
   - target_extension: "avx512"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t"]
     lscpu_flags: ["avx512f"]
-    implementation: "_mm512_store_si512(reinterpret_cast<void *>(assume_aligned<Vec::vector_alignment()>(memory)), data);"
+    implementation: "_mm512_store_si512(reinterpret_cast<void*>(assume_aligned<Vec::vector_alignment()>(memory)), data);"
   - target_extension: "avx512"
     ctype: ["float", "double"]
     lscpu_flags: ["avx512f"]
-    implementation: "_mm512_store_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void *>(assume_aligned<Vec::vector_alignment()>(memory)), data);"
+    implementation: "_mm512_store_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(assume_aligned<Vec::vector_alignment()>(memory)), data);"
 #INTEL - AVX2
   - target_extension: "avx2"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t"]
@@ -258,7 +258,7 @@ definitions:
 primitive_name: "storeu"
 brief_description: "Stores data from a vector register to (un)aligned memory."
 parameters:
-  - ctype: "typename Vec::base_type *"
+  - ctype: "typename Vec::base_type*"
     name: "memory"
     description: "(Un)aligned memory where the data should be stored into."
   - ctype: "const typename Vec::register_type"
@@ -289,11 +289,11 @@ definitions:
   - target_extension: "avx512"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t"]
     lscpu_flags: ["avx512f"]
-    implementation: "_mm512_storeu_si512(reinterpret_cast<void *>(memory), data);"
+    implementation: "_mm512_storeu_si512(reinterpret_cast<void*>(memory), data);"
   - target_extension: "avx512"
     ctype: ["float", "double"]
     lscpu_flags: ["avx512f"]
-    implementation: "_mm512_storeu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void *>(memory), data);"
+    implementation: "_mm512_storeu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(memory), data);"
 #INTEL - AVX2
   - target_extension: "avx2"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t"]
@@ -712,7 +712,7 @@ definitions:
 ---
 primitive_name: "gather"
 brief_description: "Transfers data from arbitrary locations into a vector register."
-additional_simd_template_parameter: 
+additional_simd_template_parameter:
   name: "IndicesType"
   default_value:  "typename Vec::offset_register_type"
 additional_non_specialized_template_parameters:
@@ -720,7 +720,7 @@ additional_non_specialized_template_parameters:
     name: "N"
     default_value: "sizeof(typename Vec::base_type)"
 parameters:
-  - ctype: "const void *"
+  - ctype: "const void*"
     name: "memory"
     description: "(Start)pointer of the memory (which is used as base for address calculation)."
   - ctype: "const typename IndicesType::register_type"
@@ -740,7 +740,7 @@ testing:
     implementation: |
       constexpr size_t test_mem_size = 256;
       constexpr size_t test_mem_offset = test_mem_size / 2;
-      constexpr size_t iteration_count = 16;      
+      constexpr size_t iteration_count = 16;
       testing::test_memory_helper_t<Vec> test_helper{test_mem_size, Vec::vector_element_count(), true, testing::seq_init_start_0<typename Vec::base_type>};
       testing::test_memory_helper_t<IndicesType> test_helper_indices{
           iteration_count * Vec::vector_element_count(), 0, true,
@@ -842,8 +842,8 @@ definitions:
 ---
 primitive_name: "gather"
 functor_name: "mask_gather"
-additional_simd_template_parameter: 
-  name: "IndicesType" 
+additional_simd_template_parameter:
+  name: "IndicesType"
   default_value: "typename Vec::offset_register_type"
 brief_description: "If mask[i] is 1, load memory[index[i] * scale], otherwise use source[i]"
 additional_non_specialized_template_parameters:
@@ -856,7 +856,7 @@ parameters:
   - ctype: "const typename Vec::register_type"
     name: "source"
     description: "Vector register containing values which should be preserved depending on the mask (if mask[i] == 0)."
-  - ctype: "const void *"
+  - ctype: "const void*"
     name: "memory"
     description: "(Start)pointer of the memory (which is used as base for address calculation)."
   - ctype: "const typename IndicesType::offset_base_register_type"
@@ -965,7 +965,7 @@ parameters:
   - ctype: "const typename Vec::register_type"
     name: "data"
     description: "Vector register containing values which should be scattered to memory."
-  - ctype: "void *"
+  - ctype: "void*"
     name: "memory"
     description: "(Start)pointer of the memory (which is used as base for address calculation)."
   - ctype: "const typename Vec::offset_base_register_type"
@@ -1092,7 +1092,7 @@ parameters:
   - ctype: "const typename Vec::register_type"
     name: "data"
     description: "Vector register containing values which should be scattered to memory."
-  - ctype: "void *"
+  - ctype: "void*"
     name: "memory"
     description: "(Start)pointer of the memory (which is used as base for address calculation)."
   - ctype: "const typename Vec::offset_base_register_type"
@@ -1219,7 +1219,7 @@ definitions:
 ...
 #---
 #primitive_name: "gather"
-#additional_simd_template_parameter: 
+#additional_simd_template_parameter:
 #  name: "OffsetType"
 #brief_description: "Transfers data from arbitrary locations into a vector register."
 #additional_non_specialized_template_parameters:
@@ -1257,7 +1257,7 @@ parameters:
   - ctype: "const typename Vec::imask_type"
     name: "mask"
     description: "Mask"
-  - ctype: "typename Vec::base_type *"
+  - ctype: "typename Vec::base_type*"
     name: "memory"
     description: "Memory"
   - ctype: "const typename Vec::register_type"
@@ -1337,7 +1337,7 @@ parameters:
   - ctype: "const typename Vec::register_type"
     name: "src"
     description: "Source register. Data is kept if corresponding mask bit is set to 0."
-  - ctype: "typename Vec::base_type *"
+  - ctype: "typename Vec::base_type*"
     name: "memory"
     description: "Memory"
 returns:
@@ -1412,7 +1412,7 @@ definitions:
 ...
 ---
 primitive_name: "load_convert_up"
-additional_simd_template_parameter: 
+additional_simd_template_parameter:
   name: "ToType"
 parameters:
   - ctype: "typename Vec::base_type const *"

--- a/primitive_data/primitives/ls.yaml
+++ b/primitive_data/primitives/ls.yaml
@@ -736,17 +736,17 @@ definitions:
     additional_simd_template_extension: "avx512"
     ctype: ["uint32_t", "uint64_t", "int32_t", "int64_t"]
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_i{{ intrin_tp[ctype][1] }}gather_epi{{ intrin_tp[ctype][1] }}(index, memory, scale());"
+    implementation: "return _mm512_i{{ intrin_tp[ctype][1] }}gather_epi{{ intrin_tp[ctype][1] }}(index, memory, N);"
   - target_extension: "avx512"
     additional_simd_template_extension: "avx512"
     ctype: ["float"]
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_i32gather_ps(index, memory, scale());"
+    implementation: "return _mm512_i32gather_ps(index, memory, N);"
   - target_extension: "avx512"
     additional_simd_template_extension: "avx512"
     ctype: ["double"]
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_i64gather_pd(index, memory, scale());"
+    implementation: "return _mm512_i64gather_pd(index, memory, N);"
   #INTEL - AVX512 / AVX2
   - target_extension: "avx512"
     additional_simd_template_extension: "avx2"
@@ -757,28 +757,28 @@ definitions:
       "double": ["int32_t"]
     }
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_i{{ intrin_tp[additional_simd_template_base_type][1] }}gather_epi{{ intrin_tp[ctype][1] }}(index, memory, scale());"
+    implementation: "return _mm512_i{{ intrin_tp[additional_simd_template_base_type][1] }}gather_epi{{ intrin_tp[ctype][1] }}(index, memory, N);"
   #INTEL - AVX2
   - target_extension: "avx2"
     additional_simd_template_extension: "avx2"
     ctype: ["uint64_t", "int64_t"]
     lscpu_flags: ["avx2"]
-    implementation: "return _mm256_i64gather_epi64(reinterpret_cast<long long int const *>(memory), index, scale());"
+    implementation: "return _mm256_i64gather_epi64(reinterpret_cast<long long int const *>(memory), index, N);"
   - target_extension: "avx2"
     additional_simd_template_extension: "avx2"
     ctype: ["uint32_t", "int32_t"]
     lscpu_flags: ["avx2"]
-    implementation: "return _mm256_i32gather_epi32(reinterpret_cast<int const *>(memory), index, scale());"
+    implementation: "return _mm256_i32gather_epi32(reinterpret_cast<int const *>(memory), index, N);"
   - target_extension: "avx2"
     additional_simd_template_extension: "avx2"
     ctype: ["float"]
     lscpu_flags: ["avx2"]
-    implementation: "return _mm256_i32gather_ps(reinterpret_cast<float const *>(memory), index, scale());"
+    implementation: "return _mm256_i32gather_ps(reinterpret_cast<float const *>(memory), index, N);"
   - target_extension: "avx2"
     additional_simd_template_extension: "avx2"
     ctype: ["double"]
     lscpu_flags: ["avx2"]
-    implementation: "return _mm256_i64gather_pd(reinterpret_cast<double const *>(memory), index, scale());"
+    implementation: "return _mm256_i64gather_pd(reinterpret_cast<double const *>(memory), index, N);"
   #INTEL - SSE
   - target_extension: "sse"
     additional_simd_template_extension: "sse"
@@ -803,7 +803,7 @@ definitions:
         } else {
           auto mem = reinterpret_cast<char const*>(memory);
           for(std::size_t i = 0; i < Vec::vector_element_count(); ++i) {
-            result[i] = mem[idx_array[i]*scale()];
+            result[i] = mem[idx_array[i]*N];
           }
         }
       }
@@ -859,38 +859,38 @@ definitions:
     additional_simd_template_extension: "avx512"
     ctype: ["uint32_t", "uint64_t", "int32_t", "int64_t"]
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_mask_i{{ intrin_tp[ctype][1] }}gather_epi{{ intrin_tp[ctype][1] }}(source, mask, index, memory, scale());"
+    implementation: "return _mm512_mask_i{{ intrin_tp[ctype][1] }}gather_epi{{ intrin_tp[ctype][1] }}(source, mask, index, memory, N);"
   - target_extension: "avx512"
     additional_simd_template_extension: "avx512"
     ctype: ["float"]
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_mask_i32gather_ps(source, mask, index, memory, scale());"
+    implementation: "return _mm512_mask_i32gather_ps(source, mask, index, memory, N);"
   - target_extension: "avx512"
     additional_simd_template_extension: "avx512"
     ctype: ["double"]
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_mask_i64gather_pd(source, mask, index, memory, scale());"
+    implementation: "return _mm512_mask_i64gather_pd(source, mask, index, memory, N);"
   #INTEL - AVX2
   - target_extension: "avx2"
     additional_simd_template_extension: "avx2"
     ctype: ["uint64_t", "int64_t"]
     lscpu_flags: ["avx2"]
-    implementation: "return _mm256_mask_i64gather_epi64(source, reinterpret_cast<long long int const *>(memory), index, mask, scale());"
+    implementation: "return _mm256_mask_i64gather_epi64(source, reinterpret_cast<long long int const *>(memory), index, mask, N);"
   - target_extension: "avx2"
     additional_simd_template_extension: "avx2"
     ctype: ["uint32_t", "int32_t"]
     lscpu_flags: ["avx2"]
-    implementation: "return _mm256_mask_i32gather_epi32(source, reinterpret_cast<int const *>(memory), index, mask, scale());"
+    implementation: "return _mm256_mask_i32gather_epi32(source, reinterpret_cast<int const *>(memory), index, mask, N);"
   - target_extension: "avx2"
     additional_simd_template_extension: "avx2"
     ctype: ["float"]
     lscpu_flags: ["avx2"]
-    implementation: "return _mm256_mask_i32gather_ps(source, reinterpret_cast<float const *>(memory), index, mask, scale());"
+    implementation: "return _mm256_mask_i32gather_ps(source, reinterpret_cast<float const *>(memory), index, mask, N);"
   - target_extension: "avx2"
     additional_simd_template_extension: "avx2"
     ctype: ["double"]
     lscpu_flags: ["avx2"]
-    implementation: "return _mm256_mask_i64gather_pd(source, reinterpret_cast<double const *>(memory), index, mask, scale());"
+    implementation: "return _mm256_mask_i64gather_pd(source, reinterpret_cast<double const *>(memory), index, mask, N);"
   #INTEL - SSE
   - target_extension: "sse"
     additional_simd_template_extension: "sse"
@@ -917,7 +917,7 @@ definitions:
         } else {
           auto mem = reinterpret_cast<char const*>(memory);
           for(std::size_t i = 0; i < Vec::vector_element_count(); ++i) {
-            result[i] = (mask_array[i] == 0) ? src_array[i] : mem[idx_array[i]*scale()];
+            result[i] = (mask_array[i] == 0) ? src_array[i] : mem[idx_array[i]*N];
           }
         }
       }
@@ -966,16 +966,16 @@ definitions:
     lscpu_flags: ["avx512f"]
     implementation: |
       _mm512_i{{ intrin_tp[ctype][1] }}scatter_epi{{ intrin_tp[ctype][1] }}(
-         memory, index, data, scale()
+         memory, index, data, N
       );
   - target_extension: "avx512"
     ctype: ["float"]
     lscpu_flags: ["avx512f"]
-    implementation: "_mm512_i32scatter_ps(memory, index, data, scale());"
+    implementation: "_mm512_i32scatter_ps(memory, index, data, N);"
   - target_extension: "avx512"
     ctype: ["double"]
     lscpu_flags: ["avx512f"]
-    implementation: "_mm512_i64scatter_pd(memory, index, data, scale());"
+    implementation: "_mm512_i64scatter_pd(memory, index, data, N);"
   #INTEL - AVX2
   - target_extension: "avx2"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "uint64_t", "int64_t", "float", "double"]
@@ -1093,16 +1093,16 @@ definitions:
     lscpu_flags: ["avx512f"]
     implementation: |
       _mm512_mask_i{{ intrin_tp[ctype][1] }}scatter_epi{{ intrin_tp[ctype][1] }}(
-         memory, mask, index, data, scale()
+         memory, mask, index, data, N
       );
   - target_extension: "avx512"
     ctype: ["float"]
     lscpu_flags: ["avx512f"]
-    implementation: "_mm512_mask_i32scatter_ps(memory, mask, index, data, scale());"
+    implementation: "_mm512_mask_i32scatter_ps(memory, mask, index, data, N);"
   - target_extension: "avx512"
     ctype: ["double"]
     lscpu_flags: ["avx512f"]
-    implementation: "_mm512_mask_i64scatter_pd(memory, mask, index, data, scale());"
+    implementation: "_mm512_mask_i64scatter_pd(memory, mask, index, data, N);"
   #INTEL - AVX2
   - target_extension: "avx2"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "uint64_t", "int64_t", "float", "double"]
@@ -1230,8 +1230,8 @@ definitions:
 #    lscpu_flags: ['avx2']
 #    implementation: |
 #      auto base_addr = reinterpret_cast<int const*>(memory);
-#      _mm256_i32gather_epi32(base_addr, indices[0], scale());
-#      return _mm512_mask_i64gather_epi64( source, mask, index[0], reinterpret_cast< void const * >( memory ), scale() );
+#      _mm256_i32gather_epi32(base_addr, indices[0], N);
+#      return _mm512_mask_i64gather_epi64( source, mask, index[0], reinterpret_cast< void const * >( memory ), N );
 #...
 ---
 primitive_name: "compress_store"

--- a/primitive_data/primitives/ls.yaml
+++ b/primitive_data/primitives/ls.yaml
@@ -712,10 +712,13 @@ definitions:
 ---
 primitive_name: "gather"
 brief_description: "Transfers data from arbitrary locations into a vector register."
-additional_simd_template_parameter: "IndicesType" # NOTE(cmrs): would really like to have a default value for this (Vec in this case)
+additional_simd_template_parameter: 
+  name: "IndicesType"
+  default_value:  "typename Vec::offset_register_type"
 additional_non_specialized_template_parameters:
   - ctype: "int"
     name: "N"
+    default_value: "sizeof(typename Vec::base_type)"
 parameters:
   - ctype: "const void *"
     name: "memory"
@@ -828,8 +831,10 @@ definitions:
 ---
 primitive_name: "gather"
 functor_name: "mask_gather"
-additional_simd_template_parameter: "IndicesType" # NOTE(cmrs): would really like to have a default value for this (Vec in this case)
-brief_description: "Transfers data from arbitrary locations into a vector register."
+additional_simd_template_parameter: 
+  name: "IndicesType" 
+  default_value: "typename Vec::offset_register_type"
+brief_description: "If mask[i] is 1, load memory[index[i] * scale], otherwise use source[i]"
 additional_non_specialized_template_parameters:
   - ctype: "int"
     name: "N"
@@ -1203,7 +1208,8 @@ definitions:
 ...
 #---
 #primitive_name: "gather"
-#additional_simd_template_parameter: "OffsetType"
+#additional_simd_template_parameter: 
+#  name: "OffsetType"
 #brief_description: "Transfers data from arbitrary locations into a vector register."
 #additional_non_specialized_template_parameters:
 #  - ctype: "int"
@@ -1395,7 +1401,8 @@ definitions:
 ...
 ---
 primitive_name: "load_convert_up"
-additional_simd_template_parameter: "ToType"
+additional_simd_template_parameter: 
+  name: "ToType"
 parameters:
   - ctype: "typename Vec::base_type const *"
     name: "memory"

--- a/primitive_data/primitives/ls.yaml
+++ b/primitive_data/primitives/ls.yaml
@@ -723,92 +723,91 @@ parameters:
   - ctype: "const void *"
     name: "memory"
     description: "(Start)pointer of the memory (which is used as base for address calculation)."
-  - ctype: "const typename IndicesType::offset_base_register_type"
+  - ctype: "const typename IndicesType::register_type"
     name: "index"
     description: "Offsets array containing simd<offset_t, EXTENSION> register_types containing relative offsets to the start pointer (the number of array elements depend on the sizeof(offset_type)/sizeof(base_type) ratio, where sizeof(offset_type) should be 8)."
   - ctype: "std::integral_constant<int, N>"
     name: "scale"
     description: "Scale."
+    default_value: std::integral_constant<int, sizeof(typename Vec::base_type)>{}
     declaration_attributes: "[[maybe_unused]]"
 returns:
   ctype: "typename Vec::register_type"
   description: "Vector containing gathered data."
+testing:
+  - requires: ["storeu", "loadu"]
+    includes: ["<cstddef>", "<algorithm>", "<limits>", "<type_traits>"]
+    implementation: |
+      constexpr size_t test_mem_size = 256;
+      constexpr size_t test_mem_offset = test_mem_size / 2;
+      constexpr size_t iteration_count = 16;      
+      testing::test_memory_helper_t<Vec> test_helper{test_mem_size, Vec::vector_element_count(), true, testing::seq_init_start_0<typename Vec::base_type>};
+      testing::test_memory_helper_t<IndicesType> test_helper_indices{
+          iteration_count * Vec::vector_element_count(), 0, true,
+          testing::rnd_init_bounded<typename IndicesType::base_type>,
+          (typename IndicesType::base_type)(std::is_signed_v<typename IndicesType::base_type> ? -test_mem_offset : 0),
+          (typename IndicesType::base_type)(test_mem_offset - 1)
+      };
+      for(size_t i = 0; i < iteration_count; i++) {
+          for(size_t j = 0; j < Vec::vector_element_count(); j++) {
+              test_helper.result_ref()[j] = test_helper.data_ref()[test_helper_indices.data_ref()[i * Vec::vector_element_count() + j] + test_mem_offset];
+          }
+          auto indices = loadu<IndicesType>(test_helper_indices.data_target() + (i * Vec::vector_element_count()));
+          auto result = gather<Vec, IndicesType>(test_helper.data_target() + test_mem_offset, indices);
+          store<Vec>(test_helper.result_target(), result);
+          test_helper.synchronize();
+          if (!test_helper.validate()) return false;
+      }
+      return true;
 definitions:
   #INTEL - AVX512
   - target_extension: "avx512"
     additional_simd_template_extension: "avx512"
-    ctype: ["uint32_t", "uint64_t", "int32_t", "int64_t"]
+    ctype: ["uint32_t", "int32_t", "uint64_t", "int64_t", "float", "double"]
+    additional_simd_template_base_type_mapping_dict: {
+      "uint32_t": ["int32_t", "uint32_t"],
+      "int32_t":  ["int32_t", "uint32_t"],
+      "float":    ["int32_t", "uint32_t"],
+      "uint64_t": ["int64_t", "uint64_t"],
+      "int64_t":  ["int64_t", "uint64_t"],
+      "double":   ["int64_t", "uint64_t"],
+    }
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_i{{ intrin_tp[ctype][1] }}gather_epi{{ intrin_tp[ctype][1] }}(index, memory, N);"
-  - target_extension: "avx512"
-    additional_simd_template_extension: "avx512"
-    ctype: ["float"]
-    lscpu_flags: ['avx512f']
-    implementation: "return _mm512_i32gather_ps(index, memory, N);"
-  - target_extension: "avx512"
-    additional_simd_template_extension: "avx512"
-    ctype: ["double"]
-    lscpu_flags: ['avx512f']
-    implementation: "return _mm512_i64gather_pd(index, memory, N);"
+    implementation: "return _mm512_i{{ intrin_tp[additional_simd_template_base_type][1] }}gather_{{ intrin_tp_full[ctype].replace('epu', 'epi') }}(index, memory, N);"
   #INTEL - AVX512 / AVX2
   - target_extension: "avx512"
     additional_simd_template_extension: "avx2"
-    ctype: ["uint64_t", "int64_t"]
+    ctype: ["uint64_t", "int64_t", "double"]
     additional_simd_template_base_type_mapping_dict: {
-      "uint64_t": ["int32_t"],
-      "int64_t": ["int32_t"],
-      "double": ["int32_t"]
+      "uint64_t": ["int32_t", "uint32_t"],
+      "int64_t":  ["int32_t", "uint32_t"],
+      "double":   ["int32_t", "uint32_t"],
     }
     lscpu_flags: ['avx512f']
-    implementation: "return _mm512_i{{ intrin_tp[additional_simd_template_base_type][1] }}gather_epi{{ intrin_tp[ctype][1] }}(index, memory, N);"
-  #INTEL - AVX2
-  - target_extension: "avx2"
-    additional_simd_template_extension: "avx2"
-    ctype: ["uint64_t", "int64_t"]
-    lscpu_flags: ["avx2"]
-    implementation: "return _mm256_i64gather_epi64(reinterpret_cast<long long int const *>(memory), index, N);"
-  - target_extension: "avx2"
-    additional_simd_template_extension: "avx2"
-    ctype: ["uint32_t", "int32_t"]
-    lscpu_flags: ["avx2"]
-    implementation: "return _mm256_i32gather_epi32(reinterpret_cast<int const *>(memory), index, N);"
-  - target_extension: "avx2"
-    additional_simd_template_extension: "avx2"
-    ctype: ["float"]
-    lscpu_flags: ["avx2"]
-    implementation: "return _mm256_i32gather_ps(reinterpret_cast<float const *>(memory), index, N);"
-  - target_extension: "avx2"
-    additional_simd_template_extension: "avx2"
-    ctype: ["double"]
-    lscpu_flags: ["avx2"]
-    implementation: "return _mm256_i64gather_pd(reinterpret_cast<double const *>(memory), index, N);"
+    implementation: "return _mm512_i{{ intrin_tp[additional_simd_template_base_type][1] }}gather_{{ intrin_tp_full[ctype].replace('epu', 'epi') }}(index, memory, N);"
   #INTEL - SSE
   - target_extension: "sse"
     additional_simd_template_extension: "sse"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"]
+    additional_simd_template_base_type_mapping_dict: {
+      "int8_t":   ["int8_t", "uint8_t"],
+      "uint8_t":  ["int8_t", "uint8_t"],
+      "int16_t":  ["int16_t", "uint16_t"],
+      "uint16_t": ["int16_t", "uint16_t"],
+      "int32_t":  ["int32_t", "uint32_t"],
+      "uint32_t": ["int32_t", "uint32_t"],
+      "float":    ["int32_t", "uint32_t"],
+      "int64_t":  ["int64_t", "uint64_t"],
+      "uint64_t": ["int64_t", "uint64_t"],
+      "double":   ["int64_t", "uint64_t"],
+    }
     lscpu_flags: ['sse2']
     is_native: False
     implementation: |
       alignas(Vec::vector_size_B()) std::array<typename Vec::base_type, Vec::vector_element_count()> result{};
-      using offsetExt = typename Vec::transform_extension<Vec::offset_base_type>;
-      auto const idx_array = tsl::to_array<offsetExt>(index);
-      if constexpr(N == 1) {
-        auto mem = reinterpret_cast<char const*>(memory);
-        for(std::size_t i = 0; i < Vec::vector_element_count(); ++i) {
-          result[i] = mem[idx_array[i]];
-        }
-      } else {
-        if constexpr(N == sizeof(typename Vec::base_type)) {
-          auto mem = reinterpret_cast<typename Vec::base_type const *>(memory);
-          for(std::size_t i = 0; i < Vec::vector_element_count(); ++i) {
-            result[i] = mem[idx_array[i]];
-          }
-        } else {
-          auto mem = reinterpret_cast<char const*>(memory);
-          for(std::size_t i = 0; i < Vec::vector_element_count(); ++i) {
-            result[i] = mem[idx_array[i]*N];
-          }
-        }
+      auto const idx_array = tsl::to_array<IndicesType>(index);
+      for(std::size_t i = 0; i < Vec::vector_element_count(); ++i) {
+          result[i] = *reinterpret_cast<typename Vec::base_type const *>(reinterpret_cast<char const*>(memory) + idx_array[i] * N);
       }
       return tsl::load<Vec>(result.data());
   #ARM - NEON
@@ -824,9 +823,21 @@ definitions:
   #SCALAR
   - target_extension: "scalar"
     additional_simd_template_extension: "scalar"
+    additional_simd_template_base_type_mapping_dict: {
+      "int8_t":   ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "uint8_t":  ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "int16_t":  ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "uint16_t": ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "int32_t":  ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "uint32_t": ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "int64_t":  ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "uint64_t": ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "float":    ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+      "double":   ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"],
+    }
     ctype: [ "uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double" ]
     lscpu_flags: [ ]
-    implementation: "return reinterpret_cast<typename Vec::base_type const *>(memory)[index];"
+    implementation: "return *reinterpret_cast<typename Vec::base_type const *>(reinterpret_cast<const char*>(memory) + index * N);"
 ...
 ---
 primitive_name: "gather"

--- a/primitive_data/primitives/memory.yaml
+++ b/primitive_data/primitives/memory.yaml
@@ -10,7 +10,7 @@ parameters:
     name: "count_bytes"
     description: "Number of bytes which should be allocated."
 returns:
-  ctype: "typename Vec::base_type *"
+  ctype: "typename Vec::base_type*"
   description: "Pointer to allocated memory."
 definitions:
 #INTEL - AVX512
@@ -46,7 +46,7 @@ parameters:
     declaration_attributes: "[[maybe_unused]]"
     description: "Alignment bytes."
 returns:
-  ctype: "typename Vec::base_type *"
+  ctype: "typename Vec::base_type*"
   description: "Pointer to allocated memory."
 definitions:
 #INTEL - AVX512
@@ -74,7 +74,7 @@ definitions:
 primitive_name: "deallocate"
 brief_description: "Deallocates (possibly aligned) contiguous memory."
 parameters:
-  - ctype: "typename Vec::base_type *"
+  - ctype: "typename Vec::base_type*"
     name: "ptr"
     description: "Pointer to memory which should be deallocated."
 definitions:
@@ -104,10 +104,10 @@ primitive_name: "memory_cp"
 brief_description: "Copy memory."
 includes: ["<cstring>"]
 parameters:
-  - ctype: "typename Vec::base_type *"
+  - ctype: "typename Vec::base_type*"
     name: "dst"
     description: "Destination."
-  - ctype: "typename Vec::base_type const *"
+  - ctype: "typename Vec::base_type const*"
     name: "src"
     description: "Source."
   - ctype: "std::size_t"


### PR DESCRIPTION
This PR bundles some minor improvements that piled up on the repair branch:
- allow specifying default values for
    -  `additional_simd_template_parameter`
    -  `additional_non_specialized_template_parameters`
- fix the `gather` primitive making use of the new defaults and add testing for it
- fix unit test case generation for tests that specify an `additional_simd_template_parameter`

- improvements for tests helper functions 
  - added `integral_type_t`
  - added `rnd_init_bounded`
  - fixed additional arg passing in `test_memory_helper_t` constructors 
- proper 4 space indenting in generated files + other whitespace cleanups