### PR TITLE
Topo sorted but unified tests

### DIFF
--- a/generator/config/default_conf.yaml
+++ b/generator/config/default_conf.yaml
@@ -3,7 +3,7 @@ configuration:
    namespace:                     "tsl"
    header_file_extension:         ".hpp"
    source_file_extension:         ".cpp"
-   root_path:                     "../libs/tsl"
+   root_path:                     "./generated_tsl"
    compiler_architecture_prefix:  "-m"
    use_concepts:                  True
    emit_workaround_warnings:      True

--- a/generator/expansions/tsl_unit_test.py
+++ b/generator/expansions/tsl_unit_test.py
@@ -573,21 +573,20 @@ class TSLTestGenerator:
 
             if primitive_test == None:
                 primitive_test = TSLPrimitiveTest(case.associated_primitive_name,declaration_dict[case.associated_primitive_class_name][case.associated_primitive_name])
-            
+                primitive_class.add_primitive_test( primitive_test )
             primitive_test.add_case( case )
-            primitive_class.add_primitive_test( primitive_test )
 
             test_by_primitive_dict[primitive_class.primitive_class_name].import_includes(case.data_dict)
 
-        for prim, tsf in test_by_primitive_dict.items():
-            if prim in tests:
+        for primitiveClassTest, tsf in test_by_primitive_dict.items():
+            if primitiveClassTest in tests:
                 tsf.add_code(
                     config.get_template("expansions::unit_test").render(
                         {
                             "tsl_namespace": config.lib_namespace,
                             "known_extensions": lib.extension_set.known_extensions,
                             "known_ctypes": lib.primitive_class_set.known_ctypes,
-                            "tests": [tests[prim].as_dict()],
+                            "tests": [tests[primitiveClassTest].as_dict()],
                             "nested_namespaces": [unit_test_config["namespace"]]
                         }
                     )

--- a/generator/expansions/tsl_unit_test.py
+++ b/generator/expansions/tsl_unit_test.py
@@ -223,8 +223,8 @@ class TSLPrimitiveClassTests:
             "class_name": self.__primitive_class_name,
             "primitive_tests": [x.as_dict() for x in self.__primitive_tests]
         }
-
-
+    
+    
 class TSLTestSuite:
     @LogInit()
     def __init__(self, lib: TSLLib) -> None:
@@ -517,14 +517,12 @@ class TSLTestGenerator:
                 tsltestgenerator.log(logging.WARN,
                                     f"Could not download the necessary test header file. Check your network connection. {e}")
 
-        tests: Dict[str,List[TSLPrimitiveClassTests]] = dict()
-        primitive_class: TSLPrimitiveClassTests = None
+        tests: Dict[str,TSLPrimitiveClassTests] = dict()
         primitive_test: TSLPrimitiveTest = None
         declaration_dict: Dict[Dict[str, TSLPrimitive.Declaration]] = lib.primitive_class_set.get_declaration_dict()
 
         test_by_primitive_dict: Dict[str, TSLSourceFile] = dict()
         for pClass in lib.primitive_class_set:
-            tests[pClass.name] = []
             test_by_primitive_dict[pClass.name] = TSLSourceFile.create_from_dict(
                 root_path.joinpath(f"{pClass.name}_unit_test.cpp"),
                 {
@@ -562,39 +560,34 @@ class TSLTestGenerator:
 
         for test_data in dependency_graph.get_case_data_topological_order():
             case: TSLPrimitiveTestCase = TSLPrimitiveTestCase(test_data)
-            if primitive_class is None:
-                primitive_class = TSLPrimitiveClassTests(case.associated_primitive_class_name)
-                primitive_test = TSLPrimitiveTest(case.associated_primitive_name,
-                                                  declaration_dict[case.associated_primitive_class_name][
-                                                      case.associated_primitive_name])
-            else:
-                if primitive_class.primitive_class_name != case.associated_primitive_class_name:
-                    primitive_class.add_primitive_test(primitive_test)
-                    tests[primitive_class.primitive_class_name].append(primitive_class)
-                    primitive_class = TSLPrimitiveClassTests(case.associated_primitive_class_name)
-                    primitive_test = TSLPrimitiveTest(case.associated_primitive_name,
-                                                      declaration_dict[case.associated_primitive_class_name][
-                                                          case.associated_primitive_name])
-                if primitive_test.primitive_name != case.associated_primitive_name:
-                    primitive_class.add_primitive_test(primitive_test)
-                    primitive_test = TSLPrimitiveTest(case.associated_primitive_name,
-                                                      declaration_dict[case.associated_primitive_class_name][
-                                                          case.associated_primitive_name])
-            primitive_test.add_case(case)
+            
+            if case.associated_primitive_class_name not in tests:
+                tests[case.associated_primitive_class_name] = TSLPrimitiveClassTests(case.associated_primitive_class_name)
+            primitive_class = tests[case.associated_primitive_class_name]
+            
+            primitive_test: TSLPrimitiveTest = None
+            for tslPrimTest in primitive_class.primitive_tests:
+                if tslPrimTest.primitive_name == case.associated_primitive_name:
+                    primitive_test = tslPrimTest
+                    break
+
+            if primitive_test == None:
+                primitive_test = TSLPrimitiveTest(case.associated_primitive_name,declaration_dict[case.associated_primitive_class_name][case.associated_primitive_name])
+            
+            primitive_test.add_case( case )
+            primitive_class.add_primitive_test( primitive_test )
+
             test_by_primitive_dict[primitive_class.primitive_class_name].import_includes(case.data_dict)
-        if primitive_class is not None:
-            primitive_class.add_primitive_test(primitive_test)
-            tests[primitive_class.primitive_class_name].append(primitive_class)
 
         for prim, tsf in test_by_primitive_dict.items():
-            if tests[prim]:
+            if prim in tests:
                 tsf.add_code(
                     config.get_template("expansions::unit_test").render(
                         {
                             "tsl_namespace": config.lib_namespace,
                             "known_extensions": lib.extension_set.known_extensions,
                             "known_ctypes": lib.primitive_class_set.known_ctypes,
-                            "tests": [test.as_dict() for test in tests[prim]],
+                            "tests": [tests[prim].as_dict()],
                             "nested_namespaces": [unit_test_config["namespace"]]
                         }
                     )


### PR DESCRIPTION
This PR addresses the issue #31. The problem arose from the topological sorting, where test cases for the same primitive have different requirements and are thus seen earlier in the sorted test case chain. The lazy evaluation of the graph walking lead to the duplication of primitve class tests and thus multiple conflicting instances.