### PR TITLE
Allow for flag disjunction and synonyms in extensions

### DIFF
--- a/generator/core/model/tsl_extension.py
+++ b/generator/core/model/tsl_extension.py
@@ -29,6 +29,13 @@ class TSLExtension:
     def file_name(self) -> Path:
         return self.__file_path
 
+    def synonym_flags(self) -> YamlDataType:
+        return self.__data_dict["synonym_flags"]
+
+    @property
+    def has_synonyms(self) -> YamlDataType:
+        return "synonym_flags" in self.__data_dict
+
     def __deepcopy__(self, memodict={}):
         cls = self.__class__
         result = cls.__new__(cls)

--- a/generator/core/tsl_generator.py
+++ b/generator/core/tsl_generator.py
@@ -94,12 +94,13 @@ class TSLGenerator:
         slicer = TSLSlicer(relevant_hardware_flags, config.relevant_types)
 
         relevant_extensions_set: TSLExtensionSet = slicer.slice_extensions(self.__tsl_extension_set)
-        for extension in relevant_extensions_set:
-            if extension.has_synonyms:
-                synonym_dict: dict = extension.synonym_flags()
-                for synonym in synonym_dict:
-                    if synonym in relevant_hardware_flags:
-                        relevant_hardware_flags = list(map(lambda x: x.replace(synonym, synonym_dict[synonym]), relevant_hardware_flags))
+        if relevant_hardware_flags is not None:
+            for extension in relevant_extensions_set:
+                if extension.has_synonyms:
+                    synonym_dict: dict = extension.synonym_flags()
+                    for synonym in synonym_dict:
+                        if synonym in relevant_hardware_flags:
+                            relevant_hardware_flags = list(map(lambda x: x.replace(synonym, synonym_dict[synonym]), relevant_hardware_flags))
         slicer.update_relevant_flags( relevant_hardware_flags )
 
         if config.emit_tsl_extensions_to_file:

--- a/generator/core/tsl_generator.py
+++ b/generator/core/tsl_generator.py
@@ -94,6 +94,14 @@ class TSLGenerator:
         slicer = TSLSlicer(relevant_hardware_flags, config.relevant_types)
 
         relevant_extensions_set: TSLExtensionSet = slicer.slice_extensions(self.__tsl_extension_set)
+        for extension in relevant_extensions_set:
+            if extension.has_synonyms:
+                synonym_dict: dict = extension.synonym_flags()
+                for synonym in synonym_dict:
+                    if synonym in relevant_hardware_flags:
+                        relevant_hardware_flags = list(map(lambda x: x.replace(synonym, synonym_dict[synonym]), relevant_hardware_flags))
+        slicer.update_relevant_flags( relevant_hardware_flags )
+
         if config.emit_tsl_extensions_to_file:
             tsl_extension_name = "{% import 'core/extension_helper.template' as xht %}{{ xht.TSLCPPExtensionName(data_type, extension_name, register_size) }}"
             template = config.create_template(tsl_extension_name)

--- a/primitive_data/extensions/simd/arm/neon.yaml
+++ b/primitive_data/extensions/simd/arm/neon.yaml
@@ -2,7 +2,9 @@
 description: "Definition of the SIMD TargetExtension neon."
 vendor: "arm"
 extension_name: "neon"
-lscpu_flags: ["neon"]
+lscpu_flags: ["neon","asimd"]
+arch_flags: {neon: "arch=native", asimd: "arch=native"}
+synonym_flags: {asimd: "neon"}
 includes: ['<arm_neon.h>']
 simdT_name: "neon"
 simdT_default_size_in_bits: 128


### PR DESCRIPTION
This PR makes two contributions.
First:
Until now, lscpu flags in primitive_data definitions represent a conjunctive list of have-to-be-present flags, e.g.:
>  - target_extension: "neon"
>    ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"]
>    lscpu_flags: [ 'neon' ]
This PR enables the specification of multiple groups of flags, which are disjunctively connected, like so:
>  - target_extension: "neon"
>    ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"]
>    lscpu_flags: [['neon'],['asimd']]

The specification makes the respective  primitive relevant if *either* 'neon' *or' 'asimd' is present in the relevant hardware flags.

Second:
We introduce the new optional array _synonym_flags_ to extensions, to be used like so:
> synonym_flags: {asimd: "neon"}

For every relevant extension, if it has synonym flags, the occurence of the synonym key inside the relevant hardware flags will be replaced by the synonym value.
That is
>  fp asimd evtstrm aes pmull sha1 sha2 crc32

will be converted to
>  fp neon evtstrm aes pmull sha1 sha2 crc32