### PR TITLE
Added max and min width extension to rt

### DIFF
--- a/examples/oneAPIfpga/CMakeLists.txt
+++ b/examples/oneAPIfpga/CMakeLists.txt
@@ -29,7 +29,7 @@ include(${TSLROOT}/tsl.cmake)
 create_tsl(
   TSLGENERATOR_DIRECTORY "${TSLROOT}"
   DESTINATION "${CMAKE_BINARY_DIR}/tsl"
-	TARGETS_FLAGS "sse;sse2;ssse3;sse4_1;sse4_2;avx;avx2;avx512f;avx512dq;avx512cd;avx512bw;avx512vl;avx512_vnni;bmi1;bmi2;oneAPIfpgaDev"
+  APPEND_TARGETS_FLAGS "oneAPIfpgaDev"
   USE_CONCEPTS
 	LINK_OPTIONS ${fpga_link_options}
 )

--- a/examples/oneAPIfpga/clz_rtl_example.cpp
+++ b/examples/oneAPIfpga/clz_rtl_example.cpp
@@ -19,13 +19,13 @@ int main(void) {
 
   using namespace tsl;
   executor<runtime::cpu> cpu_executor;
-  using cpu_simd = simd<uint32_t, avx512>;
+  using cpu_simd = simd<uint32_t, typename runtime::cpu::max_width_extension_t>;
 
   executor<runtime::oneAPI_default_fpga> fpga_executor{
       sycl::property_list{sycl::property::queue::enable_profiling()}
     };
   using fpga_simd = simd<uint32_t, oneAPIfpgaRTL, 512>;
-
+  
   auto expected_result     = cpu_executor.allocate<uint32_t>(128);
   // allocate memory on host
   auto host_mem_data       = cpu_executor.allocate<uint32_t>(128);

--- a/supplementary/runtime/cpu/include/tslCPUrt.hpp
+++ b/supplementary/runtime/cpu/include/tslCPUrt.hpp
@@ -10,6 +10,9 @@ namespace tsl {
   namespace runtime {
     class cpu {
       public:
+        using max_width_extension_t = {{ avail_extension_types_dict[avail_extension_types_dict.keys()|max] }};
+        using min_width_extension_t = {{ avail_extension_types_dict[avail_extension_types_dict.keys()|min] }};
+      public:
         cpu() = default;
       public:
         template<typename T>


### PR DESCRIPTION
Added the following two types to tsl::runtime::cpu:
- `max_width_extension_t` (holds extension with highest degree of data-level-parallelism)
- `min_width_extension_t` (holds extension with minimum degree of data-level-parallelism > 1)

This can be used as shown in examples/oneAPIfpga/clz_rtl_example.cpp line 22:
```
using namespace tsl;
executor<runtime::cpu> cpu_executor;
using cpu_simd = simd<uint32_t, typename runtime::cpu::max_width_extension_t>;
```