### PR TITLE
Added mask_storeu and extended mask_add implementations

### DIFF
--- a/primitive_data/primitives/calc.yaml
+++ b/primitive_data/primitives/calc.yaml
@@ -356,10 +356,26 @@ testing:
 definitions:
 #INTEL - AVX512
   - target_extension: "avx512"
+    ctype: ["uint32_t", "int32_t", "uint64_t", "int64_t"]
+    lscpu_flags: ["avx512f"]
+    implementation: "return _mm512_mask_add_epi{{ intrin_tp[ctype][1]  }}(vec_a, mask, vec_a, vec_b);"
+  - target_extension: "avx512"
+    ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t"]
+    lscpu_flags: ["avx512bw"]
+    implementation: "return _mm512_mask_add_epi{{ intrin_tp[ctype][1]  }}(vec_a, mask, vec_a, vec_b);"
+  - target_extension: "avx512"
     ctype: ["float", "double"]
     lscpu_flags: ["avx512f"]
     implementation: "return _mm512_mask_add_{{ intrin_tp_full[ctype] }}(vec_a, mask, vec_a, vec_b);"
 #INTEL - AVX2
+  - target_extension: "avx2"
+    ctype: ["uint32_t", "int32_t", "uint64_t", "int64_t"]
+    lscpu_flags: ["avx512f", "avx512vl"]
+    implementation: "return _mm256_mask_add_epi{{ intrin_tp[ctype][1]  }}(vec_a, tsl::to_integral<Vec>(mask), vec_a, vec_b);"
+  - target_extension: "avx2"
+    ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t"]
+    lscpu_flags: ["avx512bw", "avx512vl"]
+    implementation: "return _mm256_mask_add_epi{{ intrin_tp[ctype][1]  }}(vec_a, tsl::to_integral<Vec>(mask), vec_a, vec_b);"
   - target_extension: "avx2"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "uint64_t", "int64_t"]
     lscpu_flags: ["avx"]
@@ -368,7 +384,19 @@ definitions:
     ctype: ["float", "double"]
     lscpu_flags: ["avx"]
     implementation: "return _mm256_add_{{ intrin_tp_full[ctype] }}(vec_a, _mm256_and_{{ intrin_tp_full[ctype] }}(vec_b, mask));"
+  - target_extension: "avx2"
+    ctype: ["float", "double"]
+    lscpu_flags: ["avx512f", "avx512vl"]
+    implementation: "return _mm256_mask_add_{{ intrin_tp_full[ctype] }}(vec_a, mask, vec_a, vec_b);"
 #INTEL - SSE
+  - target_extension: "sse"
+    ctype: ["uint32_t", "int32_t", "uint64_t", "int64_t"]
+    lscpu_flags: ["avx512f", "avx512vl"]
+    implementation: "return _mm_mask_add_epi{{ intrin_tp[ctype][1]  }}(vec_a, tsl::to_integral<Vec>(mask), vec_a, vec_b);"
+  - target_extension: "sse"
+    ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t"]
+    lscpu_flags: ["avx512bw", "avx512vl"]
+    implementation: "return _mm_mask_add_epi{{ intrin_tp[ctype][1]  }}(vec_a, tsl::to_integral<Vec>(mask), vec_a, vec_b);"
   - target_extension: "sse"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "uint64_t", "int64_t"]
     lscpu_flags: ["sse2"]
@@ -381,6 +409,10 @@ definitions:
     ctype: ["double"]
     lscpu_flags: ["sse2"]
     implementation: "return _mm_add_pd(vec_a, _mm_and_pd(vec_b, mask));"
+  - target_extension: "sse"
+    ctype: ["float", "double"]
+    lscpu_flags: ["avx512f", "avx512vl"]
+    implementation: "return _mm_mask_add_{{ intrin_tp_full[ctype] }}(vec_a, mask, vec_a, vec_b);"
 #SCALAR
   - target_extension: "scalar"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "uint64_t", "int64_t", "float", "double"]

--- a/primitive_data/primitives/ls.yaml
+++ b/primitive_data/primitives/ls.yaml
@@ -347,6 +347,116 @@ definitions:
       }
 ...
 ---
+primitive_name: "storeu"
+functor_name: "mask_storeu"
+brief_description: "Stores data from a vector register to (un)aligned memory."
+parameters:
+  - ctype: "const typename Vec::mask_type"
+    name: "mask"
+    description: "Vector mask register indicating which elements that should be saved."
+  - ctype: "typename Vec::base_type*"
+    name: "memory"
+    description: "(Un)aligned memory where the data should be stored into."
+  - ctype: "const typename Vec::register_type"
+    name: "data"
+    description: "Vector containing the data."
+testing:
+  - test_name: "all_zero_mask"
+    requires: ["to_mask", "integral_all_false", "set1"]
+    implementation: |
+      using T = typename Vec::base_type;
+      using reg_t = typename Vec::register_type;
+
+      typename Vec::mask_type mask = to_mask<Vec>(integral_all_false<Vec>());
+
+      std::size_t element_count = 1024;
+      testing::test_memory_helper_t<Vec> test_helper{Vec::vector_element_count(), false};
+      bool allOk = true;
+      auto reference_result_ptr = test_helper.result_ref();
+      auto test_result_ptr = test_helper.result_target();
+
+      for(std::size_t i = 0; i < (element_count - Vec::vector_element_count()); i += Vec::vector_element_count()){
+        for(size_t j = i; j < i + Vec::vector_element_count(); ++j) {
+          reference_result_ptr[j-i] = j;
+          test_result_ptr[j-i] = j;
+        }
+        auto vec = set1<Vec>(0);
+        storeu<Vec>(mask, test_result_ptr, vec);
+        test_helper.synchronize();
+        allOk &= test_helper.validate();
+      }
+      return allOk;
+  - test_name: "all_one_mask"
+    requires: ["to_mask", "integral_all_true", "set1"]
+    implementation: |
+      using T = typename Vec::base_type;
+      using reg_t = typename Vec::register_type;
+
+      typename Vec::mask_type mask = to_mask<Vec>(integral_all_true<Vec>());
+
+      std::size_t element_count = 1024;
+      testing::test_memory_helper_t<Vec> test_helper{Vec::vector_element_count(), false};
+      bool allOk = true;
+      auto reference_result_ptr = test_helper.result_ref();
+      auto test_result_ptr = test_helper.result_target();
+
+      for(std::size_t i = 0; i < (element_count - Vec::vector_element_count()); i += Vec::vector_element_count()){
+        for(size_t j = i; j < i + Vec::vector_element_count(); ++j) {
+          reference_result_ptr[j-i] = i;
+        }
+        auto vec = set1<Vec>(i);
+        storeu<Vec>(mask, test_result_ptr, vec);
+        test_helper.synchronize();
+        allOk &= test_helper.validate();
+      }
+      return allOk;
+definitions:
+#INTEL - AVX512
+  - target_extension: "avx512"
+    ctype: ["uint32_t", "uint64_t", "int32_t", "int64_t"]
+    lscpu_flags: ["avx512f"]
+    implementation: "return _mm512_mask_storeu_epi{{ intrin_tp[ctype][1]  }}(reinterpret_cast<void*>(memory), mask, data);"
+  - target_extension: "avx512"
+    ctype: ["uint8_t", "uint16_t", "int8_t", "int16_t"]
+    lscpu_flags: ["avx512bw"]
+    implementation: "return _mm512_mask_storeu_epi{{ intrin_tp[ctype][1]  }}(reinterpret_cast<void*>(memory), mask, data);"
+  - target_extension: "avx512"
+    ctype: ["float", "double"]
+    lscpu_flags: ["avx512f"]
+    implementation: "return _mm512_mask_storeu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(memory), mask, data);"
+#INTEL - AVX2
+  - target_extension: "avx2"
+    ctype: ["uint32_t", "uint64_t", "int32_t", "int64_t"]
+    lscpu_flags: ["avx512f", "avx512vl"]
+    implementation: "return _mm256_mask_storeu_epi{{ intrin_tp[ctype][1]  }}(reinterpret_cast<void*>(memory), tsl::to_integral<Vec>(mask), data);"
+  - target_extension: "avx2"
+    ctype: ["uint8_t", "uint16_t", "int8_t", "int16_t"]
+    lscpu_flags: ["avx512bw", "avx512vl"]
+    implementation: "return _mm256_mask_storeu_epi{{ intrin_tp[ctype][1]  }}(reinterpret_cast<void*>(memory), tsl::to_integral<Vec>(mask), data);"
+  - target_extension: "avx2"
+    ctype: ["float", "double"]
+    lscpu_flags: ["avx512f", "avx512vl"]
+    implementation: "return _mm256_mask_storeu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(memory), tsl::to_integral<Vec>(mask), data);"
+#INTEL - SSE
+  - target_extension: "sse"
+    ctype: ["uint32_t", "uint64_t", "int32_t", "int64_t"]
+    lscpu_flags: ["avx512f", "avx512vl"]
+    implementation: "return _mm_mask_storeu_epi{{ intrin_tp[ctype][1]  }}(reinterpret_cast<void*>(memory), tsl::to_integral<Vec>(mask), data);"
+  - target_extension: "sse"
+    ctype: ["uint8_t", "uint16_t", "int8_t", "int16_t"]
+    lscpu_flags: ["avx512bw", "avx512vl"]
+    implementation: "return _mm_mask_storeu_epi{{ intrin_tp[ctype][1]  }}(reinterpret_cast<void*>(memory), tsl::to_integral<Vec>(mask), data);"
+  - target_extension: "sse"
+    ctype: ["float", "double"]
+    lscpu_flags: ["avx512f", "avx512vl"]
+    implementation: "return _mm_mask_storeu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(memory), tsl::to_integral<Vec>(mask), data);"
+#SCALAR
+  - target_extension: "scalar"
+    ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"]
+    lscpu_flags: []
+    implementation: "if(mask){*memory = data;}"
+...
+---
 primitive_name: "to_array"
 brief_description: "Stores SIMD register to array."
 parameters:


### PR DESCRIPTION
### Hashing Primitives that don't create a cycle during 

Added mask_storeu intrinsic for Intel AVX512 supported hardware and scalar only.

Extended mask_add with primitives for integer values. Includes additional versions for mask_add AVX2 and SSE if AVX512 is present.