### PR TITLE
Py cpuflags

### DIFF
--- a/detect_flags.py
+++ b/detect_flags.py
@@ -1,0 +1,84 @@
+# https://stackoverflow.com/a/377028
+def which(program):
+    import os
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, _ = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ.get("PATH", "").split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+    return None
+
+def get_compile_info_from_compiler(compiler: str, arch_string: str):
+    import subprocess, re, platform
+    info = ""
+    if "clang" in compiler:
+        ps = subprocess.Popen(("clang", "-E", "-", arch_string, "-###"), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        info = ps.stderr.read().decode("utf-8")
+        return(re.findall(r'"-target-feature" "\+([^\"]+)"', info))
+    elif "g++" in compiler:
+        ps = subprocess.Popen(("g++", "-E", "-", arch_string, "-###"), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        info = ps.stderr.read().decode("utf-8")
+        return(re.findall(r' -m((?!no-)[^\s]+)', info))
+
+def get_compile_info_from_lscpu():
+    import subprocess, re, os
+    if which("lscpu"):
+        my_env = os.environ.copy()
+        my_env["LANG"] = "en"
+        ps = subprocess.Popen(("lscpu"), env=my_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        info2 = ps.stderr.read()
+        info = ps.stdout.read()
+        lines = info.decode("utf-8").split("\n")
+        
+        regex = re.compile(r"\s*Flags:\s*(?P<flags>(\w+\s)*(\w+))")
+        flags_set = set()
+        for line in lines:
+            if line.lstrip().lower().startswith("flags"):
+                for _, match in enumerate(regex.finditer(line)):
+                    for flag in match.group("flags").split(" "):
+                        flags_set.add(flag)
+        return flags_set
+    else:
+        print("No LSCPU")
+        return set()
+
+def get_platform():
+    import platform
+    if "Darwin" in platform.system():
+        return "Apple"
+    else:
+        return platform.system()
+
+import platform
+arch = platform.uname()[4]
+# if "x86" in arch:
+#     print(f"x86 CPU on {get_platform()}")
+#     arch_string = "-march=native"
+# elif "aarch" in arch or "Apple" in get_platform():
+#     print("ARM CPU or Apple System")
+
+flags = set()
+
+if which("lscpu"):
+    flags = get_compile_info_from_lscpu()
+else:
+    
+    arch_string = ""
+    if "Apple" in get_platform() or "aarch" in arch:
+        arch_string = "-mcpu=native"
+    else:
+        arch_string = "-march=native"
+    
+    print("Debug:", arch, get_platform())
+    gcc_flags = get_compile_info_from_compiler("g++", "-march=native") if which("g++") else set()
+    clang_flags = get_compile_info_from_compiler("clang", arch_string) if which("clang") else set()
+    flags = gcc_flags + clang_flags
+    
+print(' '.join(sorted(flags)))

--- a/detect_flags.py
+++ b/detect_flags.py
@@ -1,6 +1,10 @@
+import platform
+import os
+import subprocess
+import re
+
 # https://stackoverflow.com/a/377028
 def which(program):
-    import os
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
@@ -16,7 +20,6 @@ def which(program):
     return None
 
 def get_compile_info_from_compiler(compiler: str, arch_string: str):
-    import subprocess, re, platform
     info = ""
     if "clang" in compiler:
         ps = subprocess.Popen(("clang", "-E", "-", arch_string, "-###"), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -28,7 +31,7 @@ def get_compile_info_from_compiler(compiler: str, arch_string: str):
         return(re.findall(r' -m((?!no-)[^\s]+)', info))
 
 def get_compile_info_from_lscpu():
-    import subprocess, re, os
+
     if which("lscpu"):
         my_env = os.environ.copy()
         my_env["LANG"] = "en"
@@ -50,13 +53,11 @@ def get_compile_info_from_lscpu():
         return set()
 
 def get_platform():
-    import platform
     if "Darwin" in platform.system():
         return "Apple"
     else:
         return platform.system()
 
-import platform
 arch = platform.uname()[4]
 # if "x86" in arch:
 #     print(f"x86 CPU on {get_platform()}")

--- a/xx.req.txt
+++ b/xx.req.txt
@@ -1,8 +1,0 @@
-jaal>=0.1.5
-Jinja2>=3.1.2
-networkx>=3.0
-pandas>=1.5.3
-PyYAML>=6.0
-PyYAML>=6.0.1
-tools>=0.1.9
-wget>=3.2


### PR DESCRIPTION
Added a script that 
* gets rid of the py-cpuinfo dependency
* uses LSCPU, if available
* queries g++ and clang for their view on which native flags to use and returns a union of their flags

Removed the stray xxx.req.txt toplevel file.