### PR TITLE
Added constexpr else branch to fix misleading compiler warning on a bitshift overflow

### DIFF
--- a/.github/workflows/docker/emulate_x86_archlinux.dockerfile
+++ b/.github/workflows/docker/emulate_x86_archlinux.dockerfile
@@ -1,31 +1,32 @@
 FROM archlinux:latest
 
-RUN pacman --noconfirm -Syu && \
-    pacman --noconfirm -S git base-devel go 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Create a non-root user for using yay safely
-RUN useradd -m auruser && \
-    echo "auruser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN pacman -Syu --noconfirm --needed \
+        base-devel \
+        go \
+        git \
+        curl \
+        ca-certificates \
+        tar \
+        xz \
+    && pacman -Scc --noconfirm
 
-# Switch to the new user
-USER auruser
-WORKDIR /home/auruser
+# Install Intel SDE directly instead of using the AUR package.
+# The AUR package can fail when Intel updates/replaces the tarball
+# before the PKGBUILD checksum is updated.
+ARG SDE_VERSION=10.8.0-2026-03-15
+ARG SDE_URL=https://downloadmirror.intel.com/915934/sde-external-10.8.0-2026-03-15-lin.tar.xz
+ARG SDE_SHA256=50B320CD226ACEF7A491F5B321FC1BE3C3C7984F9E27A456E64894B5B0979DD3
 
-# Install yay
-RUN git clone https://aur.archlinux.org/yay-bin.git /home/auruser/yay-bin && \
-    cd /home/auruser/yay-bin && \
-    makepkg -si --noconfirm && \
-    rm -rf /home/auruser/yay-bin
+RUN curl -fL --retry 3 "${SDE_URL}" -o /tmp/intel-sde.tar.xz \
+    && echo "${SDE_SHA256}  /tmp/intel-sde.tar.xz" | sha256sum -c - \
+    && mkdir -p /opt/intel-sde \
+    && tar -xf /tmp/intel-sde.tar.xz --strip-components=1 -C /opt/intel-sde \
+    && rm -f /tmp/intel-sde.tar.xz
 
-# Set PATH (optional, but ensures yay is found)
-ENV PATH="/home/auruser/.local/bin:$PATH"
+ENV PATH="/opt/intel-sde:${PATH}"
 
-# Install an AUR package globally
-RUN yay -Sy --noconfirm intel-sde
-
-# Switch back to root
-USER root
-
-RUN rm /var/cache/pacman/pkg/*
+RUN sde64 --version || sde --version
 
 WORKDIR /tsl

--- a/generator/static_files/core/utils/functional.yaml
+++ b/generator/static_files/core/utils/functional.yaml
@@ -33,8 +33,9 @@ implementations:
         }
         if constexpr (N >= width) {
             return ~T{0};
+        } else {
+          return (T{1} << N) - T{1};
         }
-        return (T{1} << N) - T{1};
     }
     #if ((__cplusplus >= 202002L) && (__has_include(<bit>)))
     #include <bit>

--- a/primitive_data/primitives/mask.yaml
+++ b/primitive_data/primitives/mask.yaml
@@ -976,7 +976,7 @@ returns:
 definitions:
   - target_extension: "avx512"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"]
-    additional_simd_template_base_type_mapping_dict: 
+    additional_simd_template_base_type_mapping_dict:
       uint64_t: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
       int64_t: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
       double: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
@@ -989,13 +989,13 @@ definitions:
       int8_t: ["uint8_t", "int8_t"]
     lscpu_flags: ["avx512f"]
     implementation: |
-      return 
-        (mask >> position) 
-        & 
+      return
+        (mask >> position)
+        &
         lowest_n_bits_imm<typename Vec::imask_type, Vec::vector_element_count()>();
   - target_extension: "avx2"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"]
-    additional_simd_template_base_type_mapping_dict: 
+    additional_simd_template_base_type_mapping_dict:
       uint64_t: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
       int64_t: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
       double: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
@@ -1008,13 +1008,13 @@ definitions:
       int8_t: ["uint8_t", "int8_t"]
     lscpu_flags: ["avx"]
     implementation: |
-      return 
-        (mask >> position) 
-        & 
+      return
+        (mask >> position)
+        &
         lowest_n_bits_imm<typename Vec::imask_type, Vec::vector_element_count()>();
   - target_extension: "sse"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"]
-    additional_simd_template_base_type_mapping_dict: 
+    additional_simd_template_base_type_mapping_dict:
       uint64_t: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
       int64_t: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
       double: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
@@ -1027,13 +1027,13 @@ definitions:
       int8_t: ["uint8_t", "int8_t"]
     lscpu_flags: ["sse"]
     implementation: |
-      return 
-        (mask >> position) 
-        & 
+      return
+        (mask >> position)
+        &
         lowest_n_bits_imm<typename Vec::imask_type, Vec::vector_element_count()>();
   - target_extension: "scalar"
     ctype: ["uint8_t", "uint16_t", "uint32_t", "uint64_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double"]
-    additional_simd_template_base_type_mapping_dict: 
+    additional_simd_template_base_type_mapping_dict:
       uint64_t: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
       int64_t: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
       double: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "float"]
@@ -1046,9 +1046,9 @@ definitions:
       int8_t: ["uint8_t", "int8_t"]
     lscpu_flags: []
     implementation: |
-      return 
-        (mask >> position) 
-        & 
+      return
+        (mask >> position)
+        &
         lowest_n_bits_imm<typename Vec::imask_type, Vec::vector_element_count()>();
 ...
 #---


### PR DESCRIPTION
The control flow would never reach this place, yet the compiler throws a concerning but misleading warning.